### PR TITLE
Fixed zephyr snowballs and a dedicated server crash caused by ISTERs

### DIFF
--- a/src/main/java/com/aether/block/AetherBlocks.java
+++ b/src/main/java/com/aether/block/AetherBlocks.java
@@ -5,6 +5,7 @@ import static net.minecraftforge.eventbus.api.EventPriority.HIGH;
 import com.aether.Aether;
 import com.aether.block.trees.GoldenOakTree;
 import com.aether.block.trees.SkyrootTree;
+import com.aether.client.ClientProxy;
 import com.aether.client.renderer.tileentity.CustomItemStackTileEntityRenderer;
 import com.aether.entity.AetherEntityTypes;
 import com.aether.item.AetherItemGroups;
@@ -261,10 +262,10 @@ public class AetherBlocks {
 					item = new WallOrFloorItem(AMBROSIUM_TORCH, AMBROSIUM_WALL_TORCH, properties);
 				}
 				else if (block == CHEST_MIMIC) {
-					item = new BlockItem(block, properties.setISTER(() -> () -> new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new)));
+					item = new BlockItem(block, properties.setISTER(() -> ClientProxy::chestMimicRenderer));
 				}
 				else if (block == TREASURE_CHEST) {
-					item = new BlockItem(block, properties.setISTER(() -> () -> new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new)));
+					item = new BlockItem(block, properties.setISTER(() -> ClientProxy::treasureChestRenderer));
 				}
 				else {
 					item = new BlockItem(block, properties);

--- a/src/main/java/com/aether/client/ClientProxy.java
+++ b/src/main/java/com/aether/client/ClientProxy.java
@@ -9,6 +9,7 @@ import com.aether.client.gui.screen.inventory.FreezerScreen;
 import com.aether.client.gui.screen.inventory.IncubatorScreen;
 import com.aether.client.renderer.entity.*;
 import com.aether.client.renderer.tileentity.ChestMimicTileEntityRenderer;
+import com.aether.client.renderer.tileentity.CustomItemStackTileEntityRenderer;
 import com.aether.client.renderer.tileentity.TreasureChestTileEntityRenderer;
 import com.aether.entity.AetherEntityTypes;
 import com.aether.inventory.container.AetherContainerTypes;
@@ -18,6 +19,8 @@ import com.aether.network.AetherPacketHandler;
 import com.aether.network.JumpPacket;
 import com.aether.tileentity.AetherTileEntityTypes;
 
+import com.aether.tileentity.ChestMimicTileEntity;
+import com.aether.tileentity.TreasureChestTileEntity;
 import com.aether.world.dimension.AetherDimensions;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -162,6 +165,14 @@ public class ClientProxy extends CommonProxy {
 	
 	public static void setTranslucentNoCrumblingRenderLayer(Block block) {
 		RenderTypeLookup.setRenderLayer(block, RenderType.getTranslucentNoCrumbling());
+	}
+
+	public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
+		return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
+	}
+
+	public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
+		return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/com/aether/entity/projectile/ZephyrSnowballEntity.java
+++ b/src/main/java/com/aether/entity/projectile/ZephyrSnowballEntity.java
@@ -50,41 +50,39 @@ public class ZephyrSnowballEntity extends AbstractFireballEntity {
 	@Override
 	protected void onImpact(RayTraceResult result) {
 		super.onImpact(result);
-		if (!this.world.isRemote) {
-			if (result.getType() == RayTraceResult.Type.ENTITY) {
-				Entity entity = ((EntityRayTraceResult)result).getEntity();
-				if (entity instanceof LivingEntity) {
-					LivingEntity livingEntity = (LivingEntity)entity;
-					boolean isPlayer = livingEntity instanceof PlayerEntity;
+		if (result.getType() == RayTraceResult.Type.ENTITY) {
+			Entity entity = ((EntityRayTraceResult)result).getEntity();
+			if (entity instanceof LivingEntity) {
+				LivingEntity livingEntity = (LivingEntity)entity;
+				boolean isPlayer = livingEntity instanceof PlayerEntity;
 
-					if (isPlayer && ((PlayerEntity)entity).inventory.armorInventory.get(0).getItem() == AetherItems.SENTRY_BOOTS) {
-						return;
-					}
+				if (isPlayer && ((PlayerEntity)entity).inventory.armorInventory.get(0).getItem() == AetherItems.SENTRY_BOOTS) {
+					return;
+				}
 
-					if (!livingEntity.isActiveItemStackBlocking()) {
-						entity.setMotion(entity.getMotion().x, entity.getMotion().y + 0.5, entity.getMotion().z);
+				if (!livingEntity.isActiveItemStackBlocking()) {
+					entity.setMotion(entity.getMotion().x, entity.getMotion().y + 0.5, entity.getMotion().z);
+				}
+				else {
+					ItemStack activeItemStack = livingEntity.getActiveItemStack();
+					activeItemStack.damageItem(1, livingEntity, p -> p.sendBreakAnimation(activeItemStack.getEquipmentSlot()));
+
+					if (activeItemStack.getCount() <= 0) {
+						world.playSound((PlayerEntity)null, entity.getPosition(), SoundEvents.ITEM_SHIELD_BREAK, SoundCategory.PLAYERS, 1.0F, 0.8F + this.world.rand.nextFloat() * 0.4F);
 					}
 					else {
-						ItemStack activeItemStack = livingEntity.getActiveItemStack();
-						activeItemStack.damageItem(1, livingEntity, p -> p.sendBreakAnimation(activeItemStack.getEquipmentSlot()));
-
-						if (activeItemStack.getCount() <= 0) {
-							world.playSound(null, entity.getPosition(), SoundEvents.ITEM_SHIELD_BREAK, SoundCategory.PLAYERS, 1.0F, 0.8F + this.world.rand.nextFloat() * 0.4F);
-						}
-						else {
-							world.playSound(null, entity.getPosition(), SoundEvents.ITEM_SHIELD_BLOCK, SoundCategory.PLAYERS, 1.0F, 0.8F + this.world.rand.nextFloat() * 0.4F);
-						}
+						world.playSound((PlayerEntity)null, entity.getPosition(), SoundEvents.ITEM_SHIELD_BLOCK, SoundCategory.PLAYERS, 1.0F, 0.8F + this.world.rand.nextFloat() * 0.4F);
 					}
-
-					entity.setMotion(entity.getMotion().x + (this.getMotion().x * 1.5F), entity.getMotion().y, entity.getMotion().z + (this.getMotion().z * 1.5F));
 				}
+				entity.setMotion(entity.getMotion().x + (this.getMotion().x * 1.5F), entity.getMotion().y, entity.getMotion().z + (this.getMotion().z * 1.5F));
 			}
-			this.remove();
 		}
+		this.remove();
 	}
 
 	@Override
 	protected void registerData() {
+		super.registerData();
 		this.setNoGravity(true);
 	}
 
@@ -95,7 +93,7 @@ public class ZephyrSnowballEntity extends AbstractFireballEntity {
 	@Override
 	public void tick() {
 		//super.tick();
-		if (this.world.isRemote || (this.func_234616_v_() == null || !this.func_234616_v_().isAlive()) && this.world.isBlockLoaded(new BlockPos(this.getPosition()))) {
+		if (this.world.isRemote || (this.func_234616_v_() == null || this.func_234616_v_().isAlive()) && this.world.isBlockLoaded(new BlockPos(this.getPosition()))) {
 			if (this.isFireballFiery()) {
 				this.setFire(1);
 			}


### PR DESCRIPTION
Changes:

-     Instead of giving a supplier of a supplier of a new ISTER, ClientProxy now has two static methods dedicated to creating these ISTERs, so we now pass in suppliers of these methods. This fixes the crash on the server.
-     ZephyrSnowballEntity now calls super.registerData() to avoid a NullPointerException when getting the item to render.
-     Fixed the isAlive() check in ZephyrSnowballEntity.tick().
-     Removed the !world.isRemote check in ZephyrSnowballEntity.onImpact(). For some reason, the snowballs wouldn't change the player's motion when it was just done on the logical server.