### PR TITLE
The sky no longer turns black between y=0-63. Fixes issue #12. Added mixin to the Aether.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,20 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
+        maven {url='https://dist.creeper.host/Sponge/maven'}
         jcenter()
         mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
 
 version = project.mc_version + '-v' +project.aether_version
 group = 'com.aether' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
@@ -32,8 +35,11 @@ minecraft {
             //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             //property 'forge.logging.console.level', 'debug'
 
+            property 'mixin.env.disableRefMap', 'true'
+            arg "--mixin=aether.mixins.json"
+
             mods {
-                examplemod {
+                aether {
                     source sourceSets.main
                 }
             }
@@ -71,6 +77,7 @@ minecraft {
 
 dependencies {
     minecraft "net.minecraftforge:forge:${project.mc_version}-${project.forge_version}"
+    annotationProcessor 'org.spongepowered:mixin:0.8:processor'
 
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${project.curios_version}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${project.curios_version}:api")
@@ -91,7 +98,8 @@ jar {
             "Implementation-Title": project.name,
             "Implementation-Version": "${version}",
             "Implementation-Vendor" :"aether",
-            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+            "MixinConfigs": "aether.mixins.json"
         ])
     }
 }
@@ -112,4 +120,8 @@ publishing {
             url "file:///${project.projectDir}/mcmodsrepo"
         }
     }
+}
+
+mixin {
+    add sourceSets.main, "aether.refmap.json"
 }

--- a/src/main/java/com/aether/client/ClientProxy.java
+++ b/src/main/java/com/aether/client/ClientProxy.java
@@ -26,16 +26,21 @@ import com.aether.world.dimension.AetherDimensions;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.RenderTypeLookup;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.renderer.entity.SpriteRenderer;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.client.world.DimensionRenderInfo;
+import net.minecraft.fluid.FluidState;
 import net.minecraft.item.Item;
 import net.minecraft.item.SpawnEggItem;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.client.event.InputUpdateEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
@@ -189,5 +194,30 @@ public class ClientProxy extends CommonProxy {
 			}
 		});
 	}
-	
+
+	/**
+	 * The purpose of this event handler is to prevent the fog from turning black near the void in the Aether.
+	 */
+	@SubscribeEvent
+	public static void onRenderFogColor(EntityViewRenderEvent.FogColors event) {
+		ActiveRenderInfo renderInfo = event.getInfo();
+		ClientWorld world = (ClientWorld) renderInfo.getRenderViewEntity().world;
+		if(world.getDimensionKey() == AetherDimensions.AETHER_WORLD) {
+			double height = renderInfo.getProjectedView().y;
+			ClientWorld.ClientWorldInfo worldInfo = world.getWorldInfo();
+			double d0 = height * worldInfo.getFogDistance();
+			FluidState fluidState = renderInfo.getFluidState();
+			if(d0 < 1.0D && !fluidState.isTagged(FluidTags.LAVA)) { // Reverse implementation of FogRenderer.updateFogColor.
+				if (d0 < 0.0D) {
+					d0 = 0.0D;
+				}
+				d0 = d0 * d0;
+				if(d0 != 0.0D) {
+					event.setRed((float) ((double) event.getRed() / d0));
+					event.setGreen((float) ((double) event.getGreen() / d0));
+					event.setBlue((float) ((double) event.getBlue() / d0));
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/com/aether/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/com/aether/mixin/client/WorldRendererMixin.java
@@ -1,0 +1,34 @@
+package com.aether.mixin.client;
+
+import com.aether.world.dimension.AetherDimensions;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.world.ClientWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(WorldRenderer.class)
+public abstract class WorldRendererMixin {
+    
+    @Shadow private ClientWorld world;
+
+    /**
+     * {@link net.minecraft.client.renderer.WorldRenderer#renderSky(MatrixStack, float)}
+     * Code injection to fix Minecraft's issue of turning the horizon black when the player is below y=63.
+     * The method checks if the world key is the same as the Aether's, and if it is, it returns 1.
+     */
+    @ModifyVariable(
+            method = "renderSky(Lcom/mojang/blaze3d/matrix/MatrixStack;F)V",
+            at = @At(value = "STORE"),
+            ordinal = 0
+    )
+    private double onRenderSky(double d0) {
+        if(world.getDimensionKey() == AetherDimensions.AETHER_WORLD) {
+            return 1.0D;
+        }
+        return d0;
+    }
+
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -1,0 +1,15 @@
+{
+  "required": true,
+  "package": "com.aether.mixin",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "refmap": "aether.refmap.json",
+  "mixins": [
+  ],
+  "client": [
+    "client.WorldRendererMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This PR adds mixins to the Aether. If this is not okay with you, then don't accept it.

This fixes issue [#12](https://github.com/Gilded-Games/The-Aether/issues/12#issue-758935524). There is one mixin applied to WorldRenderer to avoid turning the player's horizon black when below y=63. In ClientProxy, there is a new event handler for EntityViewRenderEvent.FogColors. The point of this is to reverse some calculations done in FogRenderer that causes the fog to get darker as the viewer approaches y=0. Unfortunately, since we can't divide by zero, the void will still be black below y=0.