### PR TITLE
Fixes for several issues on the tracker.

### DIFF
--- a/src/main/java/com/aether/CommonProxy.java
+++ b/src/main/java/com/aether/CommonProxy.java
@@ -79,7 +79,7 @@ public class CommonProxy {
 	
 	protected void registerSpawnPlacements() {
 		EntitySpawnPlacementRegistry.register(AetherEntityTypes.ZEPHYR, EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, ZephyrEntity::canZephyrSpawn);
-		EntitySpawnPlacementRegistry.register(AetherEntityTypes.COCKATRICE, EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, MonsterEntity::canMonsterSpawnInLight);
+		EntitySpawnPlacementRegistry.register(AetherEntityTypes.COCKATRICE, EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, CockatriceEntity::canCockatriceSpawn);
 		EntitySpawnPlacementRegistry.register(AetherEntityTypes.AECHOR_PLANT, EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AechorPlantEntity::canAechorSpawn);
 		EntitySpawnPlacementRegistry.register(AetherEntityTypes.WHIRLWIND, EntitySpawnPlacementRegistry.PlacementType.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, WhirlwindEntity::canWhirlwindSpawn);
 

--- a/src/main/java/com/aether/block/AbstractAetherFurnaceBlock.java
+++ b/src/main/java/com/aether/block/AbstractAetherFurnaceBlock.java
@@ -43,14 +43,15 @@ public abstract class AbstractAetherFurnaceBlock extends ContainerBlock {
 		return state.get(LIT)? super.getLightValue(state) : 0;
 	}
 	*/
-	
+
 	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		if (!worldIn.isRemote) {
 			this.interactWith(worldIn, pos, player);
+			return ActionResultType.CONSUME;
 		}
 		
-		return ActionResultType.PASS;
+		return ActionResultType.SUCCESS;
 	}
 	
 	protected abstract void interactWith(World worldIn, BlockPos pos, PlayerEntity player);

--- a/src/main/java/com/aether/client/gui/screen/inventory/IncubatorScreen.java
+++ b/src/main/java/com/aether/client/gui/screen/inventory/IncubatorScreen.java
@@ -21,6 +21,20 @@ public class IncubatorScreen extends ContainerScreen<IncubatorContainer> {
 	}
 
 	@Override
+	public void init() {
+		super.init();
+		this.titleX = (this.xSize - this.font.getStringPropertyWidth(this.title)) / 2;
+	}
+
+	@Override
+	public void render(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+		this.renderBackground(matrixStack);
+		this.drawGuiContainerBackgroundLayer(matrixStack, partialTicks, mouseX, mouseY);
+		super.render(matrixStack, mouseX, mouseY, partialTicks);
+		this.renderHoveredTooltip(matrixStack, mouseX, mouseY);
+	}
+
+	@Override
 	protected void drawGuiContainerBackgroundLayer(MatrixStack matrixStack, float partialTicks, int x, int y) {
 		RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
 		this.minecraft.getTextureManager().bindTexture(INCUBATOR_GUI_TEXTURES);

--- a/src/main/java/com/aether/client/renderer/entity/model/CockatriceModel.java
+++ b/src/main/java/com/aether/client/renderer/entity/model/CockatriceModel.java
@@ -28,23 +28,23 @@ public class CockatriceModel extends EntityModel<CockatriceEntity> {
         this.jaw.setRotationPoint(0.0F, -8 + 16, -4.0F);
 
         this.body = new ModelRenderer(this, 0, 0);
-        this.body.addBox(-3.0F, -3.0F, 0.0F, 6, 8, 5, 1.0F);
+        this.body.addBox(-3.0F, -3.0F, 0.0F, 6, 8, 5, 0.0F);
         this.body.setRotationPoint(0.0F, 16, 0.0F);
 
         this.legs = new ModelRenderer(this, 22, 0);
-        this.legs.addBox(-1.0F, -1.0F, -1.0F, 2, 9, 2, 0.0F);
+        this.legs.addBox(-1.0F, -1.0F, -1.0F, 2, 9, 2);
         this.legs.setRotationPoint(-2.0F, 16, 1.0F);
 
         this.legs2 = new ModelRenderer(this, 22, 0);
-        this.legs2.addBox(-1.0F, -1.0F, -1.0F, 2, 9, 2, 0.0F);
+        this.legs2.addBox(-1.0F, -1.0F, -1.0F, 2, 9, 2);
         this.legs2.setRotationPoint(2.0F, 16, 1.0F);
 
         this.wings = new ModelRenderer(this, 52, 0);
-        this.wings.addBox(-2.01F, -0.0F, -1.0F, 1, 8, 4);
+        this.wings.addBox(-1.0F, -0.0F, -1.0F, 1, 8, 4);
         this.wings.setRotationPoint(-3.0F, (16), 2.0F);
 
         this.wings2 = new ModelRenderer(this, 52, 0);
-        this.wings2.addBox(1.01F, -0.0F, -1.0F, 1, 8, 4);
+        this.wings2.addBox(0.0F, -0.0F, -1.0F, 1, 8, 4);
         this.wings2.setRotationPoint(3.0F, -4 + 16, 0.0F);
 
         this.neck = new ModelRenderer(this, 44, 0);

--- a/src/main/java/com/aether/entity/monster/CockatriceEntity.java
+++ b/src/main/java/com/aether/entity/monster/CockatriceEntity.java
@@ -4,10 +4,7 @@ import com.aether.block.AetherBlocks;
 import com.aether.entity.AetherEntityTypes;
 import com.aether.util.AetherSoundEvents;
 import net.minecraft.block.BlockState;
-import net.minecraft.entity.CreatureEntity;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.IRangedAttackMob;
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.*;
 import net.minecraft.entity.ai.attributes.AttributeModifierMap;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.goal.*;
@@ -20,6 +17,8 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.IServerWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 
@@ -57,16 +56,15 @@ public class CockatriceEntity extends MonsterEntity implements IRangedAttackMob 
                 .createMutableAttribute(Attributes.FOLLOW_RANGE, 10.0D);
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public float getBlockPathWeight(BlockPos pos, IWorldReader worldIn) {
-        return worldIn.getBlockState(pos.down()).getBlock() == AetherBlocks.AETHER_GRASS_BLOCK? 10.0F : worldIn.getBrightness(pos) - 0.5F;
-    }
-
     //@Override
     //public void move(MoverType typeIn, Vec3d pos) {
         //super.move(typeIn, new Vec3d(0, pos.getY(), 0));
     //}
+
+
+    public static boolean canCockatriceSpawn(EntityType<? extends CockatriceEntity> type, IServerWorld worldIn, SpawnReason reason, BlockPos pos, Random randomIn) {
+        return randomIn.nextInt(45) == 0 && canMonsterSpawnInLight(type, worldIn, reason, pos, randomIn); //TODO: change the bounds of nextInt to a config value.
+    }
 
     @Override
     public void attackEntityWithRangedAttack(LivingEntity target, float distanceFactor) {

--- a/src/main/java/com/aether/entity/monster/CockatriceEntity.java
+++ b/src/main/java/com/aether/entity/monster/CockatriceEntity.java
@@ -1,6 +1,5 @@
 package com.aether.entity.monster;
 
-import com.aether.block.AetherBlocks;
 import com.aether.entity.AetherEntityTypes;
 import com.aether.util.AetherSoundEvents;
 import net.minecraft.block.BlockState;

--- a/src/main/java/com/aether/entity/monster/ZephyrEntity.java
+++ b/src/main/java/com/aether/entity/monster/ZephyrEntity.java
@@ -135,7 +135,7 @@ public class ZephyrEntity extends FlyingEntity implements IMob {
 	public static boolean canZephyrSpawn(EntityType<? extends ZephyrEntity> zephyr, IWorld worldIn, SpawnReason reason,
 		BlockPos pos, Random random) {
 		AxisAlignedBB boundingBox = new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 4, pos.getY() + 4, pos.getZ() + 4);
-		return worldIn.getDifficulty() != Difficulty.PEACEFUL && random.nextInt(85) == 0
+		return worldIn.getDifficulty() != Difficulty.PEACEFUL && random.nextInt(65) == 0 //TODO: change the bounds of nextInt to a config value.
 			&& worldIn.getEntitiesWithinAABB(ZephyrEntity.class, boundingBox).size() == 0
 			&& !worldIn.containsAnyLiquid(boundingBox) && worldIn.getLight(pos) > 8
 			&& canSpawnOn(zephyr, worldIn, reason, pos, random);

--- a/src/main/java/com/aether/entity/passive/MoaEntity.java
+++ b/src/main/java/com/aether/entity/passive/MoaEntity.java
@@ -390,12 +390,8 @@ public class MoaEntity extends SaddleableEntity {
 		super.readAdditional(compound);
 		
 		this.setPlayerGrown(compound.getBoolean("PlayerGrown"));
-		UUID uuid = compound.getUniqueId("OwnerUUID");
-		if (uuid.getMostSignificantBits() != 0L || uuid.getLeastSignificantBits() != 0L) {
-			this.setOwnerUUID(uuid);
-		}
-		else {
-			this.setOwnerUUID(null);
+		if(compound.hasUniqueId("OwnerUUID")) {
+			this.setOwnerUUID(compound.getUniqueId("OwnerUUID"));
 		}
 		this.setSitting(compound.getBoolean("Sitting"));
 		this.setRemainingJumps(compound.getInt("RemainingJumps"));

--- a/src/main/java/com/aether/item/AetherItems.java
+++ b/src/main/java/com/aether/item/AetherItems.java
@@ -177,7 +177,7 @@ public class AetherItems {
 				item("zanite_gemstone", new Item(new Item.Properties().group(AetherItemGroups.AETHER_MATERIALS))),
 				item("ambrosium_shard", new AmbrosiumShardItem(new Item.Properties()
 						.food(new Food.Builder().setAlwaysEdible().fastToEat()
-							.effect(() -> new EffectInstance(Effects.INSTANT_HEALTH), 1.0F).build())
+							.effect(() -> new EffectInstance(Effects.INSTANT_HEALTH, 1), 1.0F).build())
 						.group(AetherItemGroups.AETHER_MATERIALS))),
 				item("golden_amber", new Item(new Item.Properties().group(AetherItemGroups.AETHER_MATERIALS))),
 				item("aechor_petal", new Item(new Item.Properties().group(AetherItemGroups.AETHER_MATERIALS))),

--- a/src/main/java/com/aether/world/gen/feature/AetherFeatures.java
+++ b/src/main/java/com/aether/world/gen/feature/AetherFeatures.java
@@ -3,6 +3,7 @@ package com.aether.world.gen.feature;
 import com.aether.Aether;
 import com.aether.block.AetherBlocks;
 import com.google.common.collect.ImmutableSet;
+import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
@@ -15,6 +16,7 @@ import net.minecraft.world.gen.feature.template.RuleTest;
 import net.minecraft.world.gen.foliageplacer.BlobFoliagePlacer;
 import net.minecraft.world.gen.foliageplacer.FancyFoliagePlacer;
 import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
+import net.minecraft.world.gen.placement.ChanceConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.placement.TopSolidRangeConfig;
 import net.minecraft.world.gen.trunkplacer.FancyTrunkPlacer;
@@ -38,6 +40,8 @@ public class AetherFeatures {
 
     public static final RegistryObject<Feature<NoFeatureConfig>> CRYSTAL_TREE = FEATURES.register("crystal_tree", () -> new CrystalTreeFeature(NoFeatureConfig.field_236558_a_));
 
+    public static final RegistryObject<Feature<BlockStateFeatureConfig>> LAKE = FEATURES.register("lake", () -> new AetherLakeFeature(BlockStateFeatureConfig.field_236455_a_));
+
     public static void registerConfiguredFeatures() {
         RuleTest HOLYSTONE = new BlockMatchRuleTest(AetherBlocks.HOLYSTONE);
 
@@ -49,6 +53,7 @@ public class AetherFeatures {
         register("pink_aercloud", PINK_AERCLOUD.get().withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG).range(160).square().chance(7));
 
         register("crystal_tree", CRYSTAL_TREE.get().withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG).square().chance(15));
+        register("water_lake", LAKE.get().withConfiguration(new BlockStateFeatureConfig(Blocks.WATER.getDefaultState())).withPlacement(Placement.WATER_LAKE.configure(new ChanceConfig(4))));
 
         register("tree_skyroot", Feature.TREE.withConfiguration((new BaseTreeFeatureConfig.Builder(new SimpleBlockStateProvider(AetherBlocks.SKYROOT_LOG.getDefaultState()), new SimpleBlockStateProvider(AetherBlocks.SKYROOT_LEAVES.getDefaultState()), new BlobFoliagePlacer(FeatureSpread.func_242252_a(2), FeatureSpread.func_242252_a(0), 3), new StraightTrunkPlacer(4, 2, 0), new TwoLayerFeature(1, 0, 1))).setIgnoreVines().build()).withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
         register("tree_golden_oak", Feature.TREE.withConfiguration((new BaseTreeFeatureConfig.Builder(new SimpleBlockStateProvider(AetherBlocks.GOLDEN_OAK_LOG.getDefaultState()), new SimpleBlockStateProvider(AetherBlocks.GOLDEN_OAK_LEAVES.getDefaultState()), new FancyFoliagePlacer(FeatureSpread.func_242252_a(2), FeatureSpread.func_242252_a(4), 4), new FancyTrunkPlacer(3, 11, 0), new TwoLayerFeature(0, 0, 0, OptionalInt.of(4)))).setIgnoreVines().func_236702_a_(Heightmap.Type.MOTION_BLOCKING).build()).withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(0, 0.03F, 1))));

--- a/src/main/java/com/aether/world/gen/feature/AetherLakeFeature.java
+++ b/src/main/java/com/aether/world/gen/feature/AetherLakeFeature.java
@@ -1,0 +1,139 @@
+package com.aether.world.gen.feature;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.material.Material;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.SectionPos;
+import net.minecraft.world.ISeedReader;
+import net.minecraft.world.LightType;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.feature.BlockStateFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.structure.Structure;
+
+import java.util.Random;
+
+/**
+ * @see net.minecraft.world.gen.feature.LakesFeature
+ * This class is an edited version of LakesFeature. The normal LakesFeature is hardcoded to generate either
+ * grass or mycelium, depending on the SurfaceBuilder's top block. This version generates whatever the
+ * surfacebuilder's top block is.
+ */
+public class AetherLakeFeature extends Feature<BlockStateFeatureConfig> {
+    public AetherLakeFeature(Codec<BlockStateFeatureConfig> codec) {
+        super(codec);
+    }
+
+    public boolean generate(ISeedReader reader, ChunkGenerator generator, Random rand, BlockPos pos, BlockStateFeatureConfig config) {
+        while (pos.getY() > 5 && reader.isAirBlock(pos)) {
+            pos = pos.down();
+        }
+
+        if (pos.getY() <= 4) {
+            return false;
+        } else {
+            pos = pos.down(4);
+            if (reader.func_241827_a(SectionPos.from(pos), Structure.VILLAGE).findAny().isPresent()) {
+                return false;
+            } else {
+                boolean[] aboolean = new boolean[2048];
+                int i = rand.nextInt(4) + 4;
+
+                for (int j = 0; j < i; ++j) {
+                    double d0 = rand.nextDouble() * 6.0D + 3.0D;
+                    double d1 = rand.nextDouble() * 4.0D + 2.0D;
+                    double d2 = rand.nextDouble() * 6.0D + 3.0D;
+                    double d3 = rand.nextDouble() * (16.0D - d0 - 2.0D) + 1.0D + d0 / 2.0D;
+                    double d4 = rand.nextDouble() * (8.0D - d1 - 4.0D) + 2.0D + d1 / 2.0D;
+                    double d5 = rand.nextDouble() * (16.0D - d2 - 2.0D) + 1.0D + d2 / 2.0D;
+
+                    for (int l = 1; l < 15; ++l) {
+                        for (int i1 = 1; i1 < 15; ++i1) {
+                            for (int j1 = 1; j1 < 7; ++j1) {
+                                double d6 = ((double) l - d3) / (d0 / 2.0D);
+                                double d7 = ((double) j1 - d4) / (d1 / 2.0D);
+                                double d8 = ((double) i1 - d5) / (d2 / 2.0D);
+                                double d9 = d6 * d6 + d7 * d7 + d8 * d8;
+                                if (d9 < 1.0D) {
+                                    aboolean[(l * 16 + i1) * 8 + j1] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                for (int k1 = 0; k1 < 16; ++k1) {
+                    for (int l2 = 0; l2 < 16; ++l2) {
+                        for (int k = 0; k < 8; ++k) {
+                            boolean flag = !aboolean[(k1 * 16 + l2) * 8 + k] && (k1 < 15 && aboolean[((k1 + 1) * 16 + l2) * 8 + k] || k1 > 0 && aboolean[((k1 - 1) * 16 + l2) * 8 + k] || l2 < 15 && aboolean[(k1 * 16 + l2 + 1) * 8 + k] || l2 > 0 && aboolean[(k1 * 16 + (l2 - 1)) * 8 + k] || k < 7 && aboolean[(k1 * 16 + l2) * 8 + k + 1] || k > 0 && aboolean[(k1 * 16 + l2) * 8 + (k - 1)]);
+                            if (flag) {
+                                Material material = reader.getBlockState(pos.add(k1, k, l2)).getMaterial();
+                                if (k >= 4 && material.isLiquid()) {
+                                    return false;
+                                }
+
+                                if (k < 4 && !material.isSolid() && reader.getBlockState(pos.add(k1, k, l2)) != config.state) {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                for (int l1 = 0; l1 < 16; ++l1) {
+                    for (int i3 = 0; i3 < 16; ++i3) {
+                        for (int i4 = 0; i4 < 8; ++i4) {
+                            if (aboolean[(l1 * 16 + i3) * 8 + i4]) {
+                                reader.setBlockState(pos.add(l1, i4, i3), i4 >= 4 ? Blocks.CAVE_AIR.getDefaultState() : config.state, 2);
+                            }
+                        }
+                    }
+                }
+
+                for (int i2 = 0; i2 < 16; ++i2) {
+                    for (int j3 = 0; j3 < 16; ++j3) {
+                        for (int j4 = 4; j4 < 8; ++j4) {
+                            if (aboolean[(i2 * 16 + j3) * 8 + j4]) {
+                                BlockPos blockpos = pos.add(i2, j4 - 1, j3);
+                                if (isDirt(reader.getBlockState(blockpos).getBlock()) && reader.getLightFor(LightType.SKY, pos.add(i2, j4, j3)) > 0) {
+                                    Biome biome = reader.getBiome(blockpos);
+                                    // This is changed from LakesFeature to allow the feature to match the top block of the biome it's in.
+                                    reader.setBlockState(blockpos, biome.getGenerationSettings().getSurfaceBuilderConfig().getTop(), 2);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (config.state.getMaterial() == Material.LAVA) {
+                    for (int j2 = 0; j2 < 16; ++j2) {
+                        for (int k3 = 0; k3 < 16; ++k3) {
+                            for (int k4 = 0; k4 < 8; ++k4) {
+                                boolean flag1 = !aboolean[(j2 * 16 + k3) * 8 + k4] && (j2 < 15 && aboolean[((j2 + 1) * 16 + k3) * 8 + k4] || j2 > 0 && aboolean[((j2 - 1) * 16 + k3) * 8 + k4] || k3 < 15 && aboolean[(j2 * 16 + k3 + 1) * 8 + k4] || k3 > 0 && aboolean[(j2 * 16 + (k3 - 1)) * 8 + k4] || k4 < 7 && aboolean[(j2 * 16 + k3) * 8 + k4 + 1] || k4 > 0 && aboolean[(j2 * 16 + k3) * 8 + (k4 - 1)]);
+                                if (flag1 && (k4 < 4 || rand.nextInt(2) != 0) && reader.getBlockState(pos.add(j2, k4, k3)).getMaterial().isSolid()) {
+                                    reader.setBlockState(pos.add(j2, k4, k3), Blocks.STONE.getDefaultState(), 2);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (config.state.getMaterial() == Material.WATER) {
+                    for (int k2 = 0; k2 < 16; ++k2) {
+                        for (int l3 = 0; l3 < 16; ++l3) {
+                            int l4 = 4;
+                            BlockPos blockpos1 = pos.add(k2, 4, l3);
+                            if (reader.getBiome(blockpos1).doesWaterFreeze(reader, blockpos1, false)) {
+                                reader.setBlockState(blockpos1, Blocks.ICE.getDefaultState(), 2);
+                            }
+                        }
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/main/resources/data/aether/worldgen/biome/aether_skylands.json
+++ b/src/main/resources/data/aether/worldgen/biome/aether_skylands.json
@@ -61,19 +61,19 @@
     "monster": [
       {
         "type": "aether:whirlwind",
-        "weight": 8,
+        "weight": 10,
         "minCount": 2,
         "maxCount": 2
       },
       {
         "type": "aether:cockatrice",
-        "weight": 4,
+        "weight": 100,
         "minCount": 4,
         "maxCount": 4
       },
       {
         "type": "aether:zephyr",
-        "weight": 2,
+        "weight": 50,
         "minCount": 1,
         "maxCount": 1
       }

--- a/src/main/resources/data/aether/worldgen/biome/aether_skylands.json
+++ b/src/main/resources/data/aether/worldgen/biome/aether_skylands.json
@@ -27,7 +27,7 @@
       "aether:crystal_tree"
     ],
     [
-      "minecraft:lake_water"
+      "aether:water_lake"
     ],
     [],
     [],


### PR DESCRIPTION
Fixes:
- Moas no longer throw a NullPointerException when reading their NBT data. (#15)
- Created AetherLakeFeature, which is just a slightly modified version of LakesFeature that matches the top block of the biome it's in rather than just using vanilla grass or mycelium. (#13)
- The background of the incubator screen is now darkened like all of the other container screens. (#20)
- The cockatrice model is fixed and their spawn rates have been lowered. (#18)
- Ambrosium shards now properly apply the instant health effect. (#7)
- Opening an enchanter or freezer no longer uses the item in the player's hand (#28)