### PR TITLE
Feature/portaltimer

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/AetherRendering.java
+++ b/src/main/java/com/gildedgames/aether/client/AetherRendering.java
@@ -14,15 +14,30 @@ import com.gildedgames.aether.common.entity.tile.ChestMimicTileEntity;
 import com.gildedgames.aether.common.entity.tile.SkyrootBedTileEntity;
 import com.gildedgames.aether.common.entity.tile.TreasureChestTileEntity;
 import com.gildedgames.aether.common.registry.*;
+import com.gildedgames.aether.core.capability.AetherCapabilities;
+import com.gildedgames.aether.core.capability.interfaces.IAetherPlayer;
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MainWindow;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.RenderTypeLookup;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.SpriteRenderer;
+import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.item.ItemModelsProperties;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.Mod;
@@ -135,5 +150,50 @@ public class AetherRendering
 
     private static void render(Supplier<? extends Block> block, RenderType render) {
         RenderTypeLookup.setRenderLayer(block.get(), render);
+    }
+
+    @SubscribeEvent
+    public static void onRenderOverlay(RenderGameOverlayEvent.Post event) {
+        Minecraft mc = Minecraft.getInstance();
+        ClientPlayerEntity player = mc.player;
+        MainWindow window = event.getWindow();
+        LazyOptional<IAetherPlayer> aetherPlayer = player.getCapability(AetherCapabilities.AETHER_PLAYER_CAPABILITY);
+        aetherPlayer.ifPresent(handler -> {
+            //Portal overlay
+            if(event.getType() == RenderGameOverlayEvent.ElementType.PORTAL) {
+                float timeInPortal = handler.getPrevPortalAnimTime() + (handler.getPortalAnimTime() - handler.getPrevPortalAnimTime()) * event.getPartialTicks();
+                if (timeInPortal > 0.0F) {
+                    if (timeInPortal < 1.0F) {
+                        timeInPortal = timeInPortal * timeInPortal;
+                        timeInPortal = timeInPortal * timeInPortal;
+                        timeInPortal = timeInPortal * 0.8F + 0.2F;
+                    }
+
+                    RenderSystem.disableAlphaTest();
+                    RenderSystem.disableDepthTest();
+                    RenderSystem.depthMask(false);
+                    RenderSystem.defaultBlendFunc();
+                    RenderSystem.color4f(1.0F, 1.0F, 1.0F, timeInPortal);
+                    mc.getTextureManager().bind(AtlasTexture.LOCATION_BLOCKS);
+                    TextureAtlasSprite textureatlassprite = mc.getBlockRenderer().getBlockModelShaper().getParticleIcon(AetherBlocks.AETHER_PORTAL.get().defaultBlockState());
+                    float f = textureatlassprite.getU0();
+                    float f1 = textureatlassprite.getV0();
+                    float f2 = textureatlassprite.getU1();
+                    float f3 = textureatlassprite.getV1();
+                    Tessellator tessellator = Tessellator.getInstance();
+                    BufferBuilder bufferbuilder = tessellator.getBuilder();
+                    bufferbuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
+                    bufferbuilder.vertex(0.0D, window.getScreenHeight(), -90.0D).uv(f, f3).endVertex();
+                    bufferbuilder.vertex(window.getScreenWidth(), window.getScreenHeight(), -90.0D).uv(f2, f3).endVertex();
+                    bufferbuilder.vertex(window.getScreenWidth(), 0.0D, -90.0D).uv(f2, f1).endVertex();
+                    bufferbuilder.vertex(0.0D, 0.0D, -90.0D).uv(f, f1).endVertex();
+                    tessellator.end();
+                    RenderSystem.depthMask(true);
+                    RenderSystem.enableDepthTest();
+                    RenderSystem.enableAlphaTest();
+                    RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/gildedgames/aether/core/capability/interfaces/IAetherPlayer.java
+++ b/src/main/java/com/gildedgames/aether/core/capability/interfaces/IAetherPlayer.java
@@ -32,4 +32,7 @@ public interface IAetherPlayer extends INBTSerializable<CompoundNBT>
 	void addPortalTime(int time);
 	void setPortalTimer(int timer);
 	int getPortalTimer();
+
+	float getPortalAnimTime();
+	float getPrevPortalAnimTime();
 }

--- a/src/main/java/com/gildedgames/aether/core/capability/interfaces/IAetherPlayer.java
+++ b/src/main/java/com/gildedgames/aether/core/capability/interfaces/IAetherPlayer.java
@@ -25,4 +25,11 @@ public interface IAetherPlayer extends INBTSerializable<CompoundNBT>
 
 	void setJumping(boolean isJumping);
 	boolean isJumping();
+
+	void setInPortal(boolean inPortal);
+	boolean isInPortal();
+
+	void addPortalTime(int time);
+	void setPortalTimer(int timer);
+	int getPortalTimer();
 }

--- a/src/main/java/com/gildedgames/aether/core/capability/player/AetherPlayer.java
+++ b/src/main/java/com/gildedgames/aether/core/capability/player/AetherPlayer.java
@@ -1,6 +1,5 @@
 package com.gildedgames.aether.core.capability.player;
 
-import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.common.entity.block.ParachuteEntity;
 import com.gildedgames.aether.core.api.registers.ParachuteType;
 import com.gildedgames.aether.core.capability.interfaces.IAetherPlayer;
@@ -9,13 +8,13 @@ import com.gildedgames.aether.core.registry.AetherParachuteTypes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.server.ServerWorld;
 
-import javax.annotation.Nullable;
 
 public class AetherPlayer implements IAetherPlayer
 {
 	private final PlayerEntity player;
+	private boolean isInAetherPortal = false;
+	private int aetherPortalTimer = 0;
 
 	//STORAGE
 	private ParachuteEntity parachute = null;
@@ -65,7 +64,20 @@ public class AetherPlayer implements IAetherPlayer
 	// TODO
 	@Override
 	public void onUpdate() {
+		handleAetherPortal();
+	}
 
+	/**
+	 * Increments or decrements the Aether portal timer depending on whether or not the player is inside an Aether portal.
+	 */
+	private void handleAetherPortal() {
+		if(this.isInAetherPortal) {
+			++this.aetherPortalTimer;
+			this.isInAetherPortal = false;
+		}
+		else if (this.aetherPortalTimer > 0) {
+			--this.aetherPortalTimer;
+		}
 	}
 
 	@Override
@@ -104,5 +116,30 @@ public class AetherPlayer implements IAetherPlayer
 	@Override
 	public boolean isJumping() {
 		return this.isJumping;
+	}
+
+	@Override
+	public void setInPortal(boolean inPortal) {
+		this.isInAetherPortal = inPortal;
+	}
+
+	@Override
+	public boolean isInPortal() {
+		return this.isInAetherPortal;
+	}
+
+	@Override
+	public void addPortalTime(int time) {
+		this.aetherPortalTimer += time;
+	}
+
+	@Override
+	public void setPortalTimer(int timer) {
+		this.aetherPortalTimer = timer;
+	}
+
+	@Override
+	public int getPortalTimer() {
+		return this.aetherPortalTimer;
 	}
 }


### PR DESCRIPTION
This PR adds a portal timer for players in survival so that they don't instantly travel through the portal. After 80 ticks, the player will travel through. The portal overlay also works now while the player is standing in the portal.