### PR TITLE
Added a config option to disable the custom skybox and brought back WorldRendererMixin.

### DIFF
--- a/src/main/java/com/gildedgames/aether/Aether.java
+++ b/src/main/java/com/gildedgames/aether/Aether.java
@@ -148,7 +148,7 @@ public class Aether
 					return false;
 				}
 			};
-			aetherRenderInfo.setSkyRenderHandler(new AetherSkyRenderer());
+			aetherRenderInfo.setSkyRenderHandler(AetherConfig.CLIENT.disable_aether_skybox.get() ? null : new AetherSkyRenderer());
 			DimensionRenderInfo.EFFECTS.put(AetherDimensions.AETHER_DIMENSION.location(), aetherRenderInfo);
 		});
 	}

--- a/src/main/java/com/gildedgames/aether/Aether.java
+++ b/src/main/java/com/gildedgames/aether/Aether.java
@@ -130,7 +130,13 @@ public class Aether
 	}
 
 	public void clientSetup(FMLClientSetupEvent event) {
+		AetherRendering.registerEntityRenderers(event);
+		AetherRendering.registerTileEntityRenderers();
 		event.enqueueWork(() -> {
+			AetherRendering.registerBlockRenderLayers();
+			AetherRendering.registerItemModelProperties();
+			AetherRendering.registerGuiFactories();
+			AetherRendering.registerWoodTypeAtlases();
 			DimensionRenderInfo aetherRenderInfo = new DimensionRenderInfo(-5.0F, true, DimensionRenderInfo.FogType.NORMAL, false, false) {
 				@Override
 				public Vector3d getBrightnessDependentFogColor(Vector3d color, float p_230494_2_) {
@@ -144,13 +150,6 @@ public class Aether
 			};
 			aetherRenderInfo.setSkyRenderHandler(new AetherSkyRenderer());
 			DimensionRenderInfo.EFFECTS.put(AetherDimensions.AETHER_DIMENSION.location(), aetherRenderInfo);
-
-			AetherRendering.registerBlockRenderLayers();
-			AetherRendering.registerEntityRenderers(event);
-			AetherRendering.registerTileEntityRenderers();
-			AetherRendering.registerGuiFactories();
-			AetherRendering.registerItemModelProperties();
-			AetherRendering.registerWoodTypeAtlases();
 		});
 	}
 

--- a/src/main/java/com/gildedgames/aether/core/AetherConfig.java
+++ b/src/main/java/com/gildedgames/aether/core/AetherConfig.java
@@ -1,8 +1,15 @@
 package com.gildedgames.aether.core;
 
+import com.gildedgames.aether.Aether;
+import com.gildedgames.aether.client.renderer.AetherSkyRenderer;
+import com.gildedgames.aether.common.registry.AetherDimensions;
+import net.minecraft.client.world.DimensionRenderInfo;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class AetherConfig
@@ -95,6 +102,7 @@ public class AetherConfig
 
     public static class Client {
         public final ConfigValue<Boolean> legacy_models;
+        public final ConfigValue<Boolean> disable_aether_skybox;
 
         public final ConfigValue<Boolean> enable_aether_menu;
         public final ConfigValue<Boolean> enable_aether_menu_button;
@@ -107,6 +115,9 @@ public class AetherConfig
             legacy_models = builder
                     .comment("Changes Zephyr and Aerwhale rendering to use their old models from the b1.7.3 version of the mod")
                     .define("Switches to legacy mob models", false);
+            disable_aether_skybox = builder
+                    .comment("Disables the Aether's custom skybox. Use this if you have a shader that is incompatible with custom skyboxes.")
+                    .define("Disables Aether custom skybox", false);
             builder.pop();
 
             builder.push("Gui");
@@ -144,4 +155,15 @@ public class AetherConfig
         CLIENT_SPEC = clientSpecPair.getRight();
         CLIENT = clientSpecPair.getLeft();
     }
+
+    @Mod.EventBusSubscriber(modid = Aether.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+    public static class ConfigListener {
+        @SubscribeEvent
+        public static void onConfigReload(ModConfig.Reloading event) {
+            if(event.getConfig().getType() == ModConfig.Type.CLIENT) {
+                DimensionRenderInfo.EFFECTS.get(AetherDimensions.AETHER_DIMENSION.location()).setSkyRenderHandler(CLIENT.disable_aether_skybox.get() ? null : new AetherSkyRenderer());
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/gildedgames/aether/core/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/WorldRendererMixin.java
@@ -1,0 +1,33 @@
+package com.gildedgames.aether.core.mixin.client;
+
+import com.gildedgames.aether.common.registry.AetherDimensions;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.world.ClientWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(WorldRenderer.class)
+public abstract class WorldRendererMixin {
+
+    @Shadow
+    private ClientWorld level;
+
+    /**
+     * {@link net.minecraft.client.renderer.WorldRenderer#renderSky(MatrixStack, float)}
+     * Code injection to fix Minecraft's issue of turning the horizon black when the player is below y=63.
+     * The method checks if the world key is the same as the Aether's, and if it is, it returns 1.
+     */
+    @ModifyVariable(
+            method = "renderSky(Lcom/mojang/blaze3d/matrix/MatrixStack;F)V",
+            at = @At(value = "STORE"),
+            ordinal = 0
+    )
+    private double onRenderSky(double d0) {
+        if (level.dimension() == AetherDimensions.AETHER_WORLD) {
+            return 1.0D;
+        }
+        return d0;
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -9,7 +9,8 @@
     "common.FindPollinationTargetGoalMixin"
   ],
   "client": [
-    "client.ClientRecipeBookMixin"
+    "client.ClientRecipeBookMixin",
+    "client.WorldRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This pull request adds a config option to disable the custom skybox in the Aether (issue #93). In the ClientSetupEvent, the mod will check the config setting to determine whether it will put the AetherSkyRenderHandler in the DimensionRenderInfo. It will do this again whenever the mod config is reloaded. This pull request also reintroduces the WorldRendererMixin for when the Aether doesn't have its custom skybox.