### PR TITLE
Fixed aerbunnies being attackable while mounted. Added white smoke.

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/particle/WhiteSmokeParticle.java
+++ b/src/main/java/com/gildedgames/aether/client/particle/WhiteSmokeParticle.java
@@ -1,0 +1,28 @@
+package com.gildedgames.aether.client.particle;
+
+import net.minecraft.client.particle.*;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.particles.BasicParticleType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+//Subclass of SmokeParticle to make white particles.
+public class WhiteSmokeParticle extends SmokeParticle {
+    protected WhiteSmokeParticle(ClientWorld p_i232425_1_, double p_i232425_2_, double p_i232425_4_, double p_i232425_6_, double p_i232425_8_, double p_i232425_10_, double p_i232425_12_, float p_i232425_14_, IAnimatedSprite p_i232425_15_) {
+        super(p_i232425_1_, p_i232425_2_, p_i232425_4_, p_i232425_6_, p_i232425_8_, p_i232425_10_, p_i232425_12_, p_i232425_14_, p_i232425_15_);
+        this.setColor(1.0F, 1.0F, 1.0F);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    public static class Factory implements IParticleFactory<BasicParticleType> {
+        private final IAnimatedSprite spriteset;
+
+        public Factory(IAnimatedSprite p_i51045_1_) {
+            this.spriteset = p_i51045_1_;
+        }
+
+        public Particle createParticle(BasicParticleType p_199234_1_, ClientWorld p_199234_2_, double p_199234_3_, double p_199234_5_, double p_199234_7_, double p_199234_9_, double p_199234_11_, double p_199234_13_) {
+            return new WhiteSmokeParticle(p_199234_2_, p_199234_3_, p_199234_5_, p_199234_7_, p_199234_9_, p_199234_11_, p_199234_13_, 1.0F, this.spriteset);
+        }
+    }
+}

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherParticleTypes.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherParticleTypes.java
@@ -28,6 +28,7 @@ public class AetherParticleTypes
 	public static final RegistryObject<BasicParticleType> FREEZER = PARTICLES.register("freezer", () -> new BasicParticleType(false));
 	public static final RegistryObject<BasicParticleType> PASSIVE_WHIRLWIND = PARTICLES.register("passive_whirlwind", () -> new BasicParticleType(false));
 	public static final RegistryObject<BasicParticleType> EVIL_WHIRLWIND = PARTICLES.register("evil_whirlwind", () -> new BasicParticleType(false));
+	public static final RegistryObject<BasicParticleType> WHITE_SMOKE = PARTICLES.register("white_smoke", () -> new BasicParticleType(false));
 
 	@SubscribeEvent
 	@OnlyIn(Dist.CLIENT)
@@ -41,5 +42,6 @@ public class AetherParticleTypes
 		particleManager.register(FREEZER.get(), FreezerParticle.Factory::new);
 		particleManager.register(PASSIVE_WHIRLWIND.get(), PassiveWhirlyParticle.Factory::new);
 		particleManager.register(EVIL_WHIRLWIND.get(), EvilWhirlyParticle.Factory::new);
+		particleManager.register(WHITE_SMOKE.get(), WhiteSmokeParticle.Factory::new);
 	}
 }

--- a/src/main/java/com/gildedgames/aether/common/entity/passive/AerbunnyEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/passive/AerbunnyEntity.java
@@ -1,8 +1,8 @@
 package com.gildedgames.aether.common.entity.passive;
 
+import com.gildedgames.aether.client.registry.AetherParticleTypes;
 import com.gildedgames.aether.client.registry.AetherSoundEvents;
 import com.gildedgames.aether.common.entity.AetherAnimalEntity;
-import com.gildedgames.aether.common.entity.MountableEntity;
 import com.gildedgames.aether.common.registry.AetherEntityTypes;
 import com.gildedgames.aether.common.registry.AetherItems;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
@@ -18,7 +18,6 @@ import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
-import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
@@ -107,11 +106,10 @@ public class AerbunnyEntity extends AetherAnimalEntity {
         return true;
     }
 
-    // TODO: Why doesn't this work?
-    /*@Override
+    @Override
     public boolean isInvulnerableTo(DamageSource damageSource) {
-        return damageSource.getEntity() == this.getVehicle() && super.isInvulnerableTo(damageSource);
-    }*/
+        return damageSource.getEntity() == this.getVehicle() || super.isInvulnerableTo(damageSource);
+    }
 
 
 
@@ -161,7 +159,7 @@ public class AerbunnyEntity extends AetherAnimalEntity {
                     double d5 = (float)getY() + getBbHeight() + 0.125F;
                     double d8 = (float)getZ() + random.nextFloat() * 0.25F;
                     float f1 = random.nextFloat() * 360F;
-                    this.level.addParticle(ParticleTypes.SMOKE, -Math.sin(0.01745329F * f1) * 0.75D, d5 - 0.25D, Math.cos(0.01745329F * f1) * 0.75D, d2, 0.125D, d8);
+                    this.level.addParticle(AetherParticleTypes.WHITE_SMOKE.get(), -Math.sin(0.01745329F * f1) * 0.75D, d5 - 0.25D, Math.cos(0.01745329F * f1) * 0.75D, d2, 0.125D, d8);
                 }
             }
 
@@ -205,7 +203,7 @@ public class AerbunnyEntity extends AetherAnimalEntity {
                 double d1 = this.random.nextGaussian() * 0.02D;
                 double d2 = this.random.nextGaussian() * 0.02D;
                 double d3 = 10.0D;
-                this.level.addParticle(ParticleTypes.SMOKE,
+                this.level.addParticle(AetherParticleTypes.WHITE_SMOKE.get(),
                         this.getX() + (double)(this.random.nextFloat() * this.getBbWidth() * 2.0F) - (double)this.getBbWidth() - d0 * d3,
                         this.getY() + (double)(this.random.nextFloat() * this.getBbHeight()) - d1 * d3,
                         this.getZ() + (double)(this.random.nextFloat() * this.getBbWidth() * 2.0F) - (double)this.getBbWidth() - d2 * d3,

--- a/src/main/resources/assets/aether/particles/white_smoke.json
+++ b/src/main/resources/assets/aether/particles/white_smoke.json
@@ -1,0 +1,12 @@
+{
+  "textures": [
+    "minecraft:generic_7",
+    "minecraft:generic_6",
+    "minecraft:generic_5",
+    "minecraft:generic_4",
+    "minecraft:generic_3",
+    "minecraft:generic_2",
+    "minecraft:generic_1",
+    "minecraft:generic_0"
+  ]
+}


### PR DESCRIPTION
This is a follow-up to PR #108, which added aerbunnies. This commit adds white smoke particles for the aerbunnies to use and fixes the issue where a player can attack an aerbunny while it is on their head. With this, aerbunnies should be fully functional.