### PR TITLE
Advancement sounds, Aether menu music.

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/gui/screen/menu/AetherMainMenuScreen.java
+++ b/src/main/java/com/gildedgames/aether/client/gui/screen/menu/AetherMainMenuScreen.java
@@ -1,11 +1,13 @@
 package com.gildedgames.aether.client.gui.screen.menu;
 
 import com.gildedgames.aether.client.gui.button.AetherMenuButton;
+import com.gildedgames.aether.client.registry.AetherSoundEvents;
 import com.gildedgames.aether.core.AetherConfig;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 
+import net.minecraft.client.audio.BackgroundMusicSelector;
 import net.minecraft.client.gui.screen.MainMenuScreen;
 import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.client.gui.widget.button.Button;
@@ -19,6 +21,8 @@ import net.minecraft.util.text.TranslationTextComponent;
 
 public class AetherMainMenuScreen extends MainMenuScreen
 {
+	public static final BackgroundMusicSelector MENU = new BackgroundMusicSelector(AetherSoundEvents.MUSIC_MENU.get(), 20, 600, true);
+
 	private final RenderSkybox panorama = new RenderSkybox(new RenderSkyboxCube(new ResourceLocation("aether:textures/gui/title/panorama/panorama")));
 	private static final ResourceLocation PANORAMA_OVERLAY = new ResourceLocation("textures/gui/title/background/panorama_overlay.png");
 	private static final ResourceLocation AETHER_LOGO = new ResourceLocation("aether:textures/gui/title/aether.png");
@@ -30,7 +34,7 @@ public class AetherMainMenuScreen extends MainMenuScreen
 
 	private int buttonCount;
 
-	public AetherMainMenuScreen() { }
+	public AetherMainMenuScreen() {}
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
@@ -1,0 +1,47 @@
+package com.gildedgames.aether.core.mixin.client;
+
+import com.gildedgames.aether.Aether;
+import com.gildedgames.aether.client.registry.AetherSoundEvents;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.client.audio.SimpleSound;
+import net.minecraft.client.gui.toasts.AdvancementToast;
+import net.minecraft.client.gui.toasts.IToast;
+import net.minecraft.client.gui.toasts.ToastGui;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AdvancementToast.class)
+public abstract class AdvancementToastMixin {
+    @Final @Shadow private Advancement advancement;
+    @Shadow private boolean playedSound;
+
+    /**
+     * Injector mixin to play the Aether's advancement sounds when the player gets an Aether advancement.
+     */
+    @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/matrix/MatrixStack;Lnet/minecraft/client/gui/toasts/ToastGui;J)Lnet/minecraft/client/gui/toasts/IToast$Visibility;")
+    private void onRender(MatrixStack p_230444_1_, ToastGui p_230444_2_, long p_230444_3_, CallbackInfoReturnable<IToast.Visibility> cir) {
+        if(!this.playedSound) {
+            ResourceLocation enterAether = new ResourceLocation(Aether.MODID, "enter_aether");
+            if (advancement.getId().equals(enterAether) || (advancement.getParent() != null && advancement.getParent().getId().equals(enterAether))) {
+                this.playedSound = true;
+                switch (advancement.getId().getPath()) {
+                    case "like_a_bossaru":
+                        p_230444_2_.getMinecraft().getSoundManager().play(SimpleSound.forUI(AetherSoundEvents.UI_TOAST_AETHER_BRONZE.get(), 1.0F, 1.0F));
+                        break;
+                    case "dethroned":
+                        p_230444_2_.getMinecraft().getSoundManager().play(SimpleSound.forUI(AetherSoundEvents.UI_TOAST_AETHER_SILVER.get(), 1.0F, 1.0F));
+                        break;
+                    default:
+                        p_230444_2_.getMinecraft().getSoundManager().play(SimpleSound.forUI(AetherSoundEvents.UI_TOAST_AETHER_GENERAL.get(), 1.0F, 1.0F));
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
@@ -18,10 +18,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(AdvancementToast.class)
 public abstract class AdvancementToastMixin {
-    @Final @Shadow private Advancement advancement;
-    @Shadow private boolean playedSound;
+    @Final
+    @Shadow
+    private Advancement advancement;
+    @Shadow
+    private boolean playedSound;
 
     /**
+     * {@link AdvancementToast#render(MatrixStack, ToastGui, long)}
      * Injector mixin to play the Aether's advancement sounds when the player gets an Aether advancement.
      */
     @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/matrix/MatrixStack;Lnet/minecraft/client/gui/toasts/ToastGui;J)Lnet/minecraft/client/gui/toasts/IToast$Visibility;")

--- a/src/main/java/com/gildedgames/aether/core/mixin/client/MinecraftMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/MinecraftMixin.java
@@ -1,0 +1,27 @@
+package com.gildedgames.aether.core.mixin.client;
+
+import com.gildedgames.aether.client.gui.screen.menu.AetherMainMenuScreen;
+import com.gildedgames.aether.core.AetherConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.BackgroundMusicSelector;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    /**
+     * {@link Minecraft#getSituationalMusic()}
+     * Injector mixin to make sure the game recognizes the Aether menu and doesn't try to interrupt with its own music,
+     * while also making sure that the game cuts off the Aether menu music as soon as necessary. This code is
+     * injected right before the end of the method where the main menu music is returned, so all it needs to check is
+     * the config.
+     */
+    @Inject(at = @At(value = "RETURN", ordinal = 4), method = "getSituationalMusic()Lnet/minecraft/client/audio/BackgroundMusicSelector;", cancellable = true)
+    public void onGetSituationalMusic(CallbackInfoReturnable<BackgroundMusicSelector> cir) {
+        if(AetherConfig.CLIENT.enable_aether_menu.get()) {
+            cir.setReturnValue(AetherMainMenuScreen.MENU);
+        }
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,31 +1,20 @@
 public    net.minecraft.entity.Entity field_181016_an # lastPortalPos
 public    net.minecraft.entity.Entity field_181017_ao # lastPortalVec
 public    net.minecraft.entity.Entity field_181018_ap # teleportDirection
-public    net.minecraft.entity.Entity field_71087_bX # inPortal
 public    net.minecraft.world.Teleporter$PortalPosition
 public    net.minecraft.world.Teleporter field_222275_f # columnPosMap
-public    net.minecraft.entity.player.ServerPlayerEntity field_184851_cj # invulnerableDimensionChange
-public    net.minecraft.entity.player.ServerPlayerEntity func_213846_b(Lnet/minecraft/world/server/ServerWorld;)V # func_213846_b
-public    net.minecraft.entity.player.ServerPlayerEntity field_71144_ck # lastExperience
-public    net.minecraft.entity.player.ServerPlayerEntity field_71149_ch # lastHealth
-public    net.minecraft.entity.player.ServerPlayerEntity field_71146_ci # lastFoodLevel
 public    net.minecraft.entity.projectile.ThrowableEntity field_70192_c # owner
 protected net.minecraft.client.particle.PortalParticle <init>(Lnet/minecraft/world/World;DDDDDD)V
 public net.minecraft.entity.Entity func_241839_a(Lnet/minecraft/util/Direction$Axis;Lnet/minecraft/util/TeleportationRepositioner$Result;)Lnet/minecraft/util/math/vector/Vector3d; # func_241839_a'
 public net.minecraft.entity.LivingEntity func_241839_a(Lnet/minecraft/util/Direction$Axis;Lnet/minecraft/util/TeleportationRepositioner$Result;)Lnet/minecraft/util/math/vector/Vector3d; # func_241839_a
 public net.minecraft.entity.item.minecart.AbstractMinecartEntity func_241839_a(Lnet/minecraft/util/Direction$Axis;Lnet/minecraft/util/TeleportationRepositioner$Result;)Lnet/minecraft/util/math/vector/Vector3d; # func_241839_a
 public net.minecraft.entity.item.BoatEntity func_241839_a(Lnet/minecraft/util/Direction$Axis;Lnet/minecraft/util/TeleportationRepositioner$Result;)Lnet/minecraft/util/math/vector/Vector3d; # func_241839_a
-public net.minecraft.entity.Entity field_82153_h # portalCounter
-public net.minecraft.entity.Entity field_242273_aw # portalCooldown
 
-public    net.minecraft.block.DispenserBlock field_149943_a # DISPENSE_BEHAVIOR_REGISTRY
 public-f  net.minecraft.item.AxeItem field_203176_a # BLOCK_STRIPPING_MAP
 public net.minecraft.block.ComposterBlock func_220290_a(FLnet/minecraft/util/IItemProvider;)V # registerCompostable
 public-f net.minecraft.item.HoeItem field_195973_b # HOE_LOOKUP
 
 public    net.minecraft.entity.Entity field_70146_Z # rand
-public    net.minecraft.entity.passive.SheepEntity field_200206_bz # WOOL_BY_COLOR
-protected net.minecraft.entity.monster.SlimeEntity field_184711_bt # SLIME_SIZE
 public    net.minecraft.entity.monster.SlimeEntity$FaceRandomGoal
 public    net.minecraft.entity.monster.SlimeEntity$HopGoal
 public    net.minecraft.entity.monster.SlimeEntity$FloatGoal
@@ -36,12 +25,8 @@ public    net.minecraft.entity.passive.BeeEntity func_226421_eO_()V # addCropCou
 public net.minecraft.entity.Entity field_242271_ac # field_242271_ac
 public net.minecraft.client.world.DimensionRenderInfo field_239208_a_ # field_239208_a_
 
-protected net.minecraft.inventory.Inventory field_70482_c # inventoryContents
-public    net.minecraft.inventory.container.AbstractFurnaceContainer func_217058_b(Lnet/minecraft/item/ItemStack;)Z # isFuel
-protected net.minecraft.inventory.container.FurnaceResultSlot field_75229_a # player
-protected net.minecraft.inventory.container.FurnaceResultSlot field_75228_b # removeCount
 public    net.minecraft.item.crafting.CookingRecipeSerializer$IFactory
-public    net.minecraft.tileentity.AbstractFurnaceTileEntity func_213996_a(Ljava/util/Map;Lnet/minecraft/util/IItemProvider;I)V # addItemBurnTime
+
 public    net.minecraft.tileentity.AbstractFurnaceTileEntity func_213992_a(Ljava/util/Map;Lnet/minecraft/tags/Tag;I)V # addItemTagBurnTime
 
 protected net.minecraft.block.SpreadableSnowyDirtBlock func_220256_c(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/IWorldReader;Lnet/minecraft/util/math/BlockPos;)Z
@@ -49,26 +34,15 @@ protected net.minecraft.block.SpreadableSnowyDirtBlock func_220257_b(Lnet/minecr
 public    net.minecraft.block.TorchBlock <init>(Lnet/minecraft/block/Block$Properties;)V
 public    net.minecraft.block.WallTorchBlock <init>(Lnet/minecraft/block/Block$Properties;)V
 public    net.minecraft.block.SaplingBlock <init>(Lnet/minecraft/block/trees/Tree;Lnet/minecraft/block/Block$Properties;)V
-public    net.minecraft.block.FourWayBlock field_196415_z # FACING_TO_PROPERTY_MAP
 
 protected net.minecraft.item.SwordItem field_200895_b # attackSpeed
-public    net.minecraft.item.MusicDiscItem <init>(ILnet/minecraft/util/SoundEvent;Lnet/minecraft/item/Item$Properties;)V
 
 public net.minecraft.loot.conditions.LootConditionManager func_237475_a_(Ljava/lang/String;Lnet/minecraft/loot/ILootSerializer;)Lnet/minecraft/loot/LootConditionType; # register
 public    net.minecraft.world.storage.loot.conditions.BlockStateProperty func_215984_a(Lnet/minecraft/block/Block;Ljava/util/Map;)Ljava/util/function/Predicate; # buildPredicate
 public    net.minecraft.loot.functions.LootFunctionManager func_237451_a_(Ljava/lang/String;Lnet/minecraft/loot/ILootSerializer;)Lnet/minecraft/loot/LootFunctionType; # func_237451_a_
 public    net.minecraft.data.loot.BlockLootTables field_218573_a # SILK_TOUCH
-public    net.minecraft.data.loot.BlockLootTables field_218575_c # SHEARS
 public    net.minecraft.data.loot.BlockLootTables field_218576_d # SILK_TOUCH_OR_SHEARS
 public    net.minecraft.data.loot.BlockLootTables field_218579_g # DEFAULT_SAPLING_DROP_RATES
-
-public    net.minecraft.entity.item.ItemEntity func_85054_d()V # searchForOtherItemsNearby
-
-public    net.minecraft.client.Minecraft field_175621_X # itemRenderer
-
-public    net.minecraft.world.server.ServerWorld func_229856_ab_()V # wakeUpAllPlayers
-public    net.minecraft.world.server.ServerWorld func_73051_P()V # resetRainAndThunder
-public    net.minecraft.world.server.ServerWorld field_73068_P # allPlayersSleeping
 
 public    net.minecraft.loot.LootParameterSets func_216253_a(Ljava/lang/String;Ljava/util/function/Consumer;)Lnet/minecraft/loot/LootParameterSet; # register
 
@@ -78,8 +52,6 @@ public-f  net.minecraft.world.gen.feature.structure.Structure field_236384_t_ #L
 public-f  net.minecraft.world.gen.settings.DimensionStructuresSettings field_236191_b_ #DEFAULT_STRUCTURE_CONFIGS
 public-f  net.minecraft.world.gen.FlatGenerationSettings field_202247_j #STRUCTURES
 public-f  net.minecraft.world.gen.settings.DimensionStructuresSettings field_236193_d_ #structures
-
-public    net.minecraft.tileentity.AbstractFurnaceTileEntity func_214007_c(Lnet/minecraft/item/crafting/IRecipe;)V # burn
 
 public    net.minecraft.client.renderer.entity.model.PlayerModel field_178735_y # smallArms
 public-f  net.minecraft.client.renderer.entity.model.PlayerModel field_178734_a # leftSleeve

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -15,6 +15,7 @@
     "client.AdvancementToastMixin",
     "client.ClientRecipeBookMixin",
     "client.ElytraLayerMixin",
+    "client.MinecraftMixin",
     "client.WorldRendererMixin"
   ],
   "injectors": {

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -5,16 +5,17 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "aether.refmap.json",
   "mixins": [
+    "common.CropsBlockMixin",
     "common.EatBerriesGoalMixin",
     "common.FindPollinationTargetGoalMixin",
     "common.FoxEntityMixin",
-    "common.PiglinTasksMixin",
-    "common.CropsBlockMixin"
+    "common.PiglinTasksMixin"
   ],
   "client": [
+    "client.AdvancementToastMixin",
     "client.ClientRecipeBookMixin",
-    "client.WorldRendererMixin",
-    "client.ElytraLayerMixin"
+    "client.ElytraLayerMixin",
+    "client.WorldRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR uses an injector mixin to AdvancementToast to make the Aether's advancement sounds play when the toast shows up. This might also be possible with an access transformer and packets, but that implementation is pretty over the top when the project is already using mixins and the solution with that is simple. I also included code to check for the bronze and silver dungeon advancements to play their respective sounds when they are added.

Additionally, I cleaned up the access transformers by removing any that aren't necessary.

Finally, I used a mixin to the Minecraft class's getSituationalMusic method to make the game play the Aether menu music when on the Aether menu.