### PR TITLE
aether menu screen now renders the last world you played on

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/event/listeners/GuiListener.java
+++ b/src/main/java/com/gildedgames/aether/client/event/listeners/GuiListener.java
@@ -1,25 +1,69 @@
 package com.gildedgames.aether.client.event.listeners;
 
+import com.gildedgames.aether.client.gui.screen.inventory.AetherFurnaceScreen;
 import com.gildedgames.aether.client.gui.screen.menu.AetherMainMenuScreen;
 
 import com.gildedgames.aether.core.AetherConfig;
+import com.mojang.realmsclient.RealmsMainScreen;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screen.MainMenuScreen;
-import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.*;
+import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.client.gui.widget.button.CheckboxButton;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.network.play.server.SDisconnectPacket;
+import net.minecraft.realms.RealmsScreen;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.GameType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+import java.io.File;
+import java.util.List;
+
 
 @Mod.EventBusSubscriber(Dist.CLIENT)
 public class GuiListener
 {
+
+	public static boolean load_level = false;
 	@SubscribeEvent
 	public static void onGuiInitialize(GuiScreenEvent.InitGuiEvent.Post event) {
+
+		System.out.println(event.getGui());
+		if (event.getGui() instanceof DisconnectedScreen)  {
+			if (GuiListener.load_level == true) {
+				System.out.println("load level!");
+				GuiListener.load_level = false;
+				Minecraft.getInstance().level = null;
+				if (AetherConfig.CLIENT.enable_aether_menu.get()) {
+					Minecraft.getInstance().setScreen(new AetherMainMenuScreen());
+					Minecraft.getInstance().forceSetScreen(new AetherMainMenuScreen());
+				} else {
+					Minecraft.getInstance().setScreen(new MainMenuScreen());
+					Minecraft.getInstance().forceSetScreen(new MainMenuScreen());
+				}
+			}
+		}
+
+		if (event.getGui() instanceof DirtMessageScreen ||
+		event.getGui() instanceof WorkingScreen ||
+		event.getGui() instanceof MainMenuScreen &&
+		!(event.getGui() instanceof AetherMainMenuScreen)) {
+			boolean flag = event.getGui() instanceof MainMenuScreen &&
+					!(event.getGui() instanceof AetherMainMenuScreen);
+
+			if (Minecraft.getInstance().level != null) {
+				Minecraft.getInstance().level.disconnect();
+				GuiListener.load_level = flag;
+			}
+		}
+
 		if (event.getGui() instanceof MainMenuScreen) {
 			if (AetherConfig.CLIENT.enable_aether_menu_button.get()) {
 				Screen gui = event.getGui();
@@ -39,10 +83,13 @@ public class GuiListener
 
 	@SubscribeEvent
 	public static void onGuiOpen(GuiOpenEvent event) {
+
 		if (event.getGui() instanceof MainMenuScreen) {
+
 			if (AetherConfig.CLIENT.enable_aether_menu.get()) {
 				event.setGui(new AetherMainMenuScreen());
 			}
 		}
+
 	}
 }

--- a/src/main/java/com/gildedgames/aether/core/mixin/client/MinecraftMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/MinecraftMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.audio.BackgroundMusicSelector;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Minecraft.class)
@@ -25,4 +26,5 @@ public class MinecraftMixin
             cir.setReturnValue(AetherMainMenuScreen.MENU);
         }
     }
+
 }


### PR DESCRIPTION
**edit: there's one last bug that needs to be fixed.  You stay in spectator mode after joining a world.  Fixing it right now**
added a change to the main menu panorama where the main menu uses the last world you played in as the panorama.  Mobs spawn, the sun and moon move, etc.
![image](https://user-images.githubusercontent.com/47490946/126027198-53337517-17ef-4e0f-8f1d-6c01f12309b6.png)
![image](https://user-images.githubusercontent.com/47490946/126027205-aaa3cc79-3ab6-4fc3-9431-2e45efd4b7c6.png)
