### PR TITLE
refactor: Simplified BEWLR registering.

### DIFF
--- a/src/main/java/com/gildedgames/aether/Aether.java
+++ b/src/main/java/com/gildedgames/aether/Aether.java
@@ -104,7 +104,6 @@ public class Aether {
         AetherBlocks.registerFlammability();
         AetherBlocks.registerWoodTypes();
         AetherBlocks.registerFreezables();
-        AetherBlocks.initBEWLR();
 
         AetherFeatures.registerConfiguredFeatures();
 

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -3,20 +3,26 @@ package com.gildedgames.aether.client.registry;
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.renderer.entity.model.*;
 import com.gildedgames.aether.client.renderer.entity.*;
+import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.client.renderer.tile.ChestMimicBlockEntityRenderer;
 import com.gildedgames.aether.client.renderer.tile.SkyrootBedRenderer;
 import com.gildedgames.aether.client.renderer.tile.TreasureChestRenderer;
+import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
 import com.gildedgames.aether.common.registry.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.CowModel;
 import net.minecraft.client.model.PigModel;
 import net.minecraft.client.model.SlimeModel;
 import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -139,19 +145,21 @@ public class AetherRenderers
         }
     }
 
-    /*public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
-        return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
+//    public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
+//        return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
+//    }
+//
+//    public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
+//        return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
+//    }
+
+    public static BlockEntityWithoutLevelRenderer skyrootBedRenderer() {
+        return blockEntityWithoutLevelRenderer(new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState()));
     }
 
-    public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
-        return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
+    public static BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer(BlockEntity blockEntity) {
+        return new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels(), blockEntity);
     }
-
-    public static CustomItemStackTileEntityRenderer skyrootBedRenderer() {
-        return new CustomItemStackTileEntityRenderer(SkyrootBedTileEntity::new);
-    }*/
-
-
 
     private static void registerBlockRenderer(Supplier<? extends Block> block, RenderType render) {
         ItemBlockRenderTypes.setRenderLayer(block.get(), render);

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
@@ -1,9 +1,5 @@
 package com.gildedgames.aether.client.renderer.tile;
 
-import com.gildedgames.aether.common.block.utility.SkyrootBedBlock;
-import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
-import com.gildedgames.aether.common.registry.AetherBlocks;
-import com.gildedgames.aether.common.registry.AetherItems;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -11,20 +7,20 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLevelRenderer {
+    private final BlockEntity blockEntity;
 
-    private final SkyrootBedBlockEntity skyrootBedEntity = new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState());
-
-    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet) {
+    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, BlockEntity blockEntity) {
         super(pBlockEntityRenderDispatcher, pEntityModelSet);
+        this.blockEntity = blockEntity;
     }
 
     @Override
@@ -32,8 +28,8 @@ public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLev
 
         Item item = pStack.getItem();
         if (item instanceof BlockItem blockItem) {
-            if (blockItem.getBlock() instanceof SkyrootBedBlock) {
-                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(skyrootBedEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
+            if (blockItem.getBlock() == this.blockEntity.getBlockState().getBlock()) {
+                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(this.blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
             }
         } else {
             super.renderByItem(pStack, pTransformType, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -1,22 +1,23 @@
 package com.gildedgames.aether.common.item.block;
 
-import com.gildedgames.aether.common.registry.AetherBlocks;
-import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.client.IItemRenderProperties;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
-public class SkyrootBedItem extends BlockItem {
-    public <B extends Block> SkyrootBedItem(B block, Properties tab) {
+public class EntityBlockItem extends BlockItem {
+    private Supplier<BlockEntityWithoutLevelRenderer> renderer;
+
+    public <B extends Block> EntityBlockItem(B block, Properties tab) {
         super(block, tab);
+    }
+
+    public EntityBlockItem setBEWLR(Supplier<BlockEntityWithoutLevelRenderer> renderer) {
+        this.renderer = renderer;
+        return this;
     }
 
     @Override
@@ -24,7 +25,7 @@ public class SkyrootBedItem extends BlockItem {
         consumer.accept(new IItemRenderProperties() {
             @Override
             public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
-                return AetherBlocks.AetherBEWLR;
+                return renderer.get();
             }
         });
     }

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
@@ -2,6 +2,7 @@ package com.gildedgames.aether.common.registry;
 
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.registry.AetherParticleTypes;
+import com.gildedgames.aether.client.registry.AetherRenderers;
 import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.common.block.construction.*;
 import com.gildedgames.aether.common.block.dungeon.ChestMimicBlock;
@@ -12,10 +13,9 @@ import com.gildedgames.aether.common.block.natural.*;
 import com.gildedgames.aether.common.block.util.*;
 import com.gildedgames.aether.common.block.utility.*;
 import com.gildedgames.aether.common.item.block.BurnableBlockItem;
-import com.gildedgames.aether.common.item.block.SkyrootBedItem;
+import com.gildedgames.aether.common.item.block.EntityBlockItem;
 import com.gildedgames.aether.common.world.gen.tree.GoldenOakTree;
 import com.gildedgames.aether.common.world.gen.tree.SkyrootTree;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.effect.MobEffects;
@@ -35,7 +35,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class AetherBlocks {
+public class AetherBlocks
+{
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, Aether.MODID);
 
     public static final RegistryObject<AetherPortalBlock> AETHER_PORTAL = BLOCKS.register("aether_portal", () -> new AetherPortalBlock(Block.Properties.copy(Blocks.NETHER_PORTAL)));
@@ -306,15 +307,11 @@ public class AetherBlocks {
             } else if (block == SUN_ALTAR.get()) {
                 return new BlockItem(block, new Item.Properties().fireResistant().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_BED.get()) {
-                return new SkyrootBedItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)/*.setISTER(() -> AetherRendering::skyrootBedRenderer)*/);
+                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)).setBEWLR(AetherRenderers::skyrootBedRenderer);
             } else {
                 return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             }
         };
-    }
-
-    public static void initBEWLR() {
-        AetherBEWLR = new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
     }
 
     private static boolean never(BlockState p_test_1_, BlockGetter p_test_2_, BlockPos p_test_3_) {


### PR DESCRIPTION
Simplified how we register BEWLRs. This should ideally mean we don't have to change the AetherBlockEntityWithoutLevelRenderer every time we add a new BEWLR for an item, we can just register in the same place as the block item itself.