### PR TITLE
refactor: Another iteration of BEWLR refactoring.

### DIFF
--- a/src/main/java/com/gildedgames/aether/Aether.java
+++ b/src/main/java/com/gildedgames/aether/Aether.java
@@ -104,7 +104,6 @@ public class Aether {
         AetherBlocks.registerFlammability();
         AetherBlocks.registerWoodTypes();
         AetherBlocks.registerFreezables();
-        AetherBlocks.initBEWLR();
 
         AetherFeatures.registerConfiguredFeatures();
 

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 @Mod.EventBusSubscriber(modid = Aether.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class AetherRenderers
 {
-    public static BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer = new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
+    public static final BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer = new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
 
     public static void registerBlockRenderLayers() {
         RenderType cutout = RenderType.cutout();

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -3,20 +3,26 @@ package com.gildedgames.aether.client.registry;
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.renderer.entity.model.*;
 import com.gildedgames.aether.client.renderer.entity.*;
+import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.client.renderer.tile.ChestMimicBlockEntityRenderer;
 import com.gildedgames.aether.client.renderer.tile.SkyrootBedRenderer;
 import com.gildedgames.aether.client.renderer.tile.TreasureChestRenderer;
+import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
 import com.gildedgames.aether.common.registry.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.CowModel;
 import net.minecraft.client.model.PigModel;
 import net.minecraft.client.model.SlimeModel;
 import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -139,19 +145,21 @@ public class AetherRenderers
         }
     }
 
-    /*public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
-        return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
+//    public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
+//        return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
+//    }
+//
+//    public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
+//        return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
+//    }
+
+    public static BlockEntityWithoutLevelRenderer skyrootBedRenderer() {
+        return blockEntityWithoutLevelRenderer(new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState()));
     }
 
-    public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
-        return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
+    public static BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer(BlockEntity blockEntity) {
+        return new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels(), blockEntity);
     }
-
-    public static CustomItemStackTileEntityRenderer skyrootBedRenderer() {
-        return new CustomItemStackTileEntityRenderer(SkyrootBedTileEntity::new);
-    }*/
-
-
 
     private static void registerBlockRenderer(Supplier<? extends Block> block, RenderType render) {
         ItemBlockRenderTypes.setRenderLayer(block.get(), render);

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -7,7 +7,6 @@ import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevel
 import com.gildedgames.aether.client.renderer.tile.ChestMimicBlockEntityRenderer;
 import com.gildedgames.aether.client.renderer.tile.SkyrootBedRenderer;
 import com.gildedgames.aether.client.renderer.tile.TreasureChestRenderer;
-import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
 import com.gildedgames.aether.common.registry.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.CowModel;
@@ -20,9 +19,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -33,6 +30,8 @@ import java.util.function.Supplier;
 @Mod.EventBusSubscriber(modid = Aether.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class AetherRenderers
 {
+    public static BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer = new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
+
     public static void registerBlockRenderLayers() {
         RenderType cutout = RenderType.cutout();
         RenderType translucent = RenderType.translucent();
@@ -143,22 +142,6 @@ public class AetherRenderers
 //                playerRenderer.addLayer(new EnchantedDartLayer<>(playerRenderer));
             }
         }
-    }
-
-//    public static CustomItemStackTileEntityRenderer chestMimicRenderer() {
-//        return new CustomItemStackTileEntityRenderer(ChestMimicTileEntity::new);
-//    }
-//
-//    public static CustomItemStackTileEntityRenderer treasureChestRenderer() {
-//        return new CustomItemStackTileEntityRenderer(TreasureChestTileEntity::new);
-//    }
-
-    public static BlockEntityWithoutLevelRenderer skyrootBedRenderer() {
-        return blockEntityWithoutLevelRenderer(new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState()));
-    }
-
-    public static BlockEntityWithoutLevelRenderer blockEntityWithoutLevelRenderer(BlockEntity blockEntity) {
-        return new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels(), blockEntity);
     }
 
     private static void registerBlockRenderer(Supplier<? extends Block> block, RenderType render) {

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
@@ -1,6 +1,5 @@
 package com.gildedgames.aether.client.renderer.tile;
 
-import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
 import com.gildedgames.aether.common.item.block.EntityBlockItem;
 import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -10,7 +9,6 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
@@ -18,14 +16,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import java.util.function.Supplier;
-
 @OnlyIn(Dist.CLIENT)
 public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLevelRenderer {
-    //private final Supplier<ChestMimicTileEntity> chestMimic = () -> new ChestMimicTileEntity(BlockPos.ZERO, AetherBlocks.CHEST_MIMIC.get().defaultBlockState());
-    //private final Supplier<TreasureChestTileEntity> treasureChest = () -> new TreasureChestTileEntity(BlockPos.ZERO, AetherBlocks.TREASURE_CHEST.get().defaultBlockState());
-    private final Supplier<SkyrootBedBlockEntity> skyrootBed = () -> new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState());
-
     public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet) {
         super(pBlockEntityRenderDispatcher, pEntityModelSet);
     }
@@ -36,8 +28,8 @@ public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLev
         if (item instanceof EntityBlockItem blockItem) {
             Block block = blockItem.getBlock();
             BlockEntity blockEntity = null;
-            if (block == AetherBlocks.SKYROOT_BED.get()) {
-                blockEntity = this.skyrootBed.get();
+            if (block == AetherBlocks.CHEST_MIMIC.get() || block == AetherBlocks.TREASURE_CHEST.get() || block == AetherBlocks.SKYROOT_BED.get()) {
+                blockEntity = blockItem.getBlockEntity();
             }
             if (blockEntity != null) {
                 Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
@@ -1,5 +1,8 @@
 package com.gildedgames.aether.client.renderer.tile;
 
+import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
+import com.gildedgames.aether.common.item.block.EntityBlockItem;
+import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -7,29 +10,37 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
-import net.minecraft.world.item.BlockItem;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import java.util.function.Supplier;
+
 @OnlyIn(Dist.CLIENT)
 public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLevelRenderer {
-    private final BlockEntity blockEntity;
+    //private final Supplier<ChestMimicTileEntity> chestMimic = () -> new ChestMimicTileEntity(BlockPos.ZERO, AetherBlocks.CHEST_MIMIC.get().defaultBlockState());
+    //private final Supplier<TreasureChestTileEntity> treasureChest = () -> new TreasureChestTileEntity(BlockPos.ZERO, AetherBlocks.TREASURE_CHEST.get().defaultBlockState());
+    private final Supplier<SkyrootBedBlockEntity> skyrootBed = () -> new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState());
 
-    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, BlockEntity blockEntity) {
+    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet) {
         super(pBlockEntityRenderDispatcher, pEntityModelSet);
-        this.blockEntity = blockEntity;
     }
 
     @Override
     public void renderByItem(ItemStack pStack, ItemTransforms.TransformType pTransformType, PoseStack pPoseStack, MultiBufferSource pBuffer, int pPackedLight, int pPackedOverlay) {
-
         Item item = pStack.getItem();
-        if (item instanceof BlockItem blockItem) {
-            if (blockItem.getBlock() == this.blockEntity.getBlockState().getBlock()) {
-                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(this.blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
+        if (item instanceof EntityBlockItem blockItem) {
+            Block block = blockItem.getBlock();
+            BlockEntity blockEntity = null;
+            if (block == AetherBlocks.SKYROOT_BED.get()) {
+                blockEntity = this.skyrootBed.get();
+            }
+            if (blockEntity != null) {
+                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
             }
         } else {
             super.renderByItem(pStack, pTransformType, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
@@ -1,7 +1,6 @@
 package com.gildedgames.aether.client.renderer.tile;
 
 import com.gildedgames.aether.common.item.block.EntityBlockItem;
-import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -11,7 +10,6 @@ import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -25,15 +23,9 @@ public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLev
     @Override
     public void renderByItem(ItemStack pStack, ItemTransforms.TransformType pTransformType, PoseStack pPoseStack, MultiBufferSource pBuffer, int pPackedLight, int pPackedOverlay) {
         Item item = pStack.getItem();
-        if (item instanceof EntityBlockItem blockItem) {
-            Block block = blockItem.getBlock();
-            BlockEntity blockEntity = null;
-            if (block == AetherBlocks.CHEST_MIMIC.get() || block == AetherBlocks.TREASURE_CHEST.get() || block == AetherBlocks.SKYROOT_BED.get()) {
-                blockEntity = blockItem.getBlockEntity();
-            }
-            if (blockEntity != null) {
-                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
-            }
+        if (item instanceof EntityBlockItem blockItem && blockItem.getBlockEntity().isPresent()) {
+            BlockEntity blockEntity = blockItem.getBlockEntity().orElseThrow(() -> new UnsupportedOperationException("BlockEntity was expected, but not supplied."));
+            Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
         } else {
             super.renderByItem(pStack, pTransformType, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
         }

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/AetherBlockEntityWithoutLevelRenderer.java
@@ -1,9 +1,5 @@
 package com.gildedgames.aether.client.renderer.tile;
 
-import com.gildedgames.aether.common.block.utility.SkyrootBedBlock;
-import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
-import com.gildedgames.aether.common.registry.AetherBlocks;
-import com.gildedgames.aether.common.registry.AetherItems;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -11,20 +7,20 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLevelRenderer {
+    private final BlockEntity blockEntity;
 
-    private final SkyrootBedBlockEntity skyrootBedEntity = new SkyrootBedBlockEntity(BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState());
-
-    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet) {
+    public AetherBlockEntityWithoutLevelRenderer(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, BlockEntity blockEntity) {
         super(pBlockEntityRenderDispatcher, pEntityModelSet);
+        this.blockEntity = blockEntity;
     }
 
     @Override
@@ -32,8 +28,8 @@ public class AetherBlockEntityWithoutLevelRenderer extends BlockEntityWithoutLev
 
         Item item = pStack.getItem();
         if (item instanceof BlockItem blockItem) {
-            if (blockItem.getBlock() instanceof SkyrootBedBlock) {
-                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(skyrootBedEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
+            if (blockItem.getBlock() == this.blockEntity.getBlockState().getBlock()) {
+                Minecraft.getInstance().getBlockEntityRenderDispatcher().renderItem(this.blockEntity, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);
             }
         } else {
             super.renderByItem(pStack, pTransformType, pPoseStack, pBuffer, pPackedLight, pPackedOverlay);

--- a/src/main/java/com/gildedgames/aether/client/renderer/tile/ChestMimicBlockEntityRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/tile/ChestMimicBlockEntityRenderer.java
@@ -1,6 +1,6 @@
 package com.gildedgames.aether.client.renderer.tile;
 
-import com.gildedgames.aether.common.entity.tile.ChestMimicTileEntity;
+import com.gildedgames.aether.common.entity.tile.ChestMimicBlockEntity;
 import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.gildedgames.aether.common.block.dungeon.ChestMimicBlock;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -73,7 +73,7 @@ public class ChestMimicBlockEntityRenderer<T extends BlockEntity> implements Blo
 			matrixStackIn.translate(0.5D, 0.5D, 0.5D);
 			matrixStackIn.mulPose(Vector3f.YP.rotationDegrees(-f));
 			matrixStackIn.translate(-0.5D, -0.5D, -0.5D);
-			DoubleBlockCombiner.NeighborCombineResult<? extends ChestMimicTileEntity> icallbackwrapper;
+			DoubleBlockCombiner.NeighborCombineResult<? extends ChestMimicBlockEntity> icallbackwrapper;
 			if (world != null) {
 				icallbackwrapper = chestMimicBlock.combine(blockstate, world, tileEntityIn.getBlockPos(), true);
 			} else {

--- a/src/main/java/com/gildedgames/aether/common/block/dungeon/ChestMimicBlock.java
+++ b/src/main/java/com/gildedgames/aether/common/block/dungeon/ChestMimicBlock.java
@@ -1,7 +1,7 @@
 package com.gildedgames.aether.common.block.dungeon;
 
 import com.gildedgames.aether.common.entity.monster.dungeon.MimicEntity;
-import com.gildedgames.aether.common.entity.tile.ChestMimicTileEntity;
+import com.gildedgames.aether.common.entity.tile.ChestMimicBlockEntity;
 import com.gildedgames.aether.common.registry.AetherEntityTypes;
 import com.gildedgames.aether.common.registry.AetherTileEntityTypes;
 import net.minecraft.world.entity.player.Player;
@@ -172,7 +172,7 @@ public class ChestMimicBlock extends Block implements SimpleWaterloggedBlock
 		mimic.spawnAnim();
 	}
 
-	public DoubleBlockCombiner.NeighborCombineResult<? extends ChestMimicTileEntity> combine(BlockState state, Level world, BlockPos pos, boolean override) {
+	public DoubleBlockCombiner.NeighborCombineResult<? extends ChestMimicBlockEntity> combine(BlockState state, Level world, BlockPos pos, boolean override) {
 		BiPredicate<LevelAccessor, BlockPos> bipredicate;
 		if (override) {
 			bipredicate = (worldIn, posIn) -> false;

--- a/src/main/java/com/gildedgames/aether/common/block/dungeon/TreasureChestBlock.java
+++ b/src/main/java/com/gildedgames/aether/common/block/dungeon/TreasureChestBlock.java
@@ -1,6 +1,6 @@
 package com.gildedgames.aether.common.block.dungeon;
 
-import com.gildedgames.aether.common.entity.tile.TreasureChestTileEntity;
+import com.gildedgames.aether.common.entity.tile.TreasureChestBlockEntity;
 import com.gildedgames.aether.common.registry.AetherTileEntityTypes;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.world.entity.LivingEntity;
@@ -21,7 +21,6 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.stats.Stat;
 import net.minecraft.stats.Stats;
-import net.minecraft.util.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -55,13 +54,13 @@ import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEntity> implements SimpleWaterloggedBlock
+public class TreasureChestBlock extends AbstractChestBlock<TreasureChestBlockEntity> implements SimpleWaterloggedBlock
 {
 	public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 	protected static final VoxelShape AABB = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D);
 
-	public TreasureChestBlock(BlockBehaviour.Properties properties, Supplier<BlockEntityType<? extends TreasureChestTileEntity>> tileEntityTypeSupplier) {
+	public TreasureChestBlock(BlockBehaviour.Properties properties, Supplier<BlockEntityType<? extends TreasureChestBlockEntity>> tileEntityTypeSupplier) {
 		super(properties, tileEntityTypeSupplier);
 		this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(WATERLOGGED, Boolean.FALSE));
 	}
@@ -105,8 +104,8 @@ public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEnti
 	public void setPlacedBy(Level world, BlockPos pos, BlockState state, LivingEntity livingEntity, ItemStack stack) {
 		if (stack.hasCustomHoverName()) {
 			BlockEntity tileentity = world.getBlockEntity(pos);
-			if (tileentity instanceof TreasureChestTileEntity) {
-				((TreasureChestTileEntity) tileentity).setCustomName(stack.getHoverName());
+			if (tileentity instanceof TreasureChestBlockEntity) {
+				((TreasureChestBlockEntity) tileentity).setCustomName(stack.getHoverName());
 			}
 		}
 	}
@@ -130,8 +129,8 @@ public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEnti
 	@Override
 	public float getExplosionResistance(BlockState state, BlockGetter world, BlockPos pos, Explosion explosion) {
 		BlockEntity tileEntity = world.getBlockEntity(pos);
-		if (tileEntity instanceof TreasureChestTileEntity) {
-			TreasureChestTileEntity treasureChest = (TreasureChestTileEntity) tileEntity;
+		if (tileEntity instanceof TreasureChestBlockEntity) {
+			TreasureChestBlockEntity treasureChest = (TreasureChestBlockEntity) tileEntity;
 			return treasureChest.getLocked() ? super.getExplosionResistance(state, world, pos, explosion) : 3.0F;
 		}
 		return super.getExplosionResistance(state, world, pos, explosion);
@@ -155,8 +154,8 @@ public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEnti
 			return InteractionResult.SUCCESS;
 		} else {
 			BlockEntity tileEntity = world.getBlockEntity(pos);
-			if (tileEntity instanceof TreasureChestTileEntity) {
-				TreasureChestTileEntity treasureChest = (TreasureChestTileEntity) tileEntity;
+			if (tileEntity instanceof TreasureChestBlockEntity) {
+				TreasureChestBlockEntity treasureChest = (TreasureChestBlockEntity) tileEntity;
 				MenuProvider inamedcontainerprovider = this.getMenuProvider(state, world, pos);
 				if (treasureChest.getLocked()) {
 					ItemStack stack = player.getMainHandItem();
@@ -181,10 +180,10 @@ public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEnti
 	@Override
 	public ItemStack getCloneItemStack(BlockGetter reader, BlockPos pos, BlockState state) {
 		ItemStack stack = super.getCloneItemStack(reader, pos, state);
-		TreasureChestTileEntity treasureChestTileEntity = (TreasureChestTileEntity) reader.getBlockEntity(pos);
+		TreasureChestBlockEntity treasureChestBlockEntity = (TreasureChestBlockEntity) reader.getBlockEntity(pos);
 		CompoundTag compound = new CompoundTag();
-		compound.putBoolean("Locked", treasureChestTileEntity.getLocked());
-		compound.putString("Kind", treasureChestTileEntity.getKind());
+		compound.putBoolean("Locked", treasureChestBlockEntity.getLocked());
+		compound.putString("Kind", treasureChestBlockEntity.getKind());
 		stack.addTagElement("BlockEntityTag", compound);
 		return stack;
 	}
@@ -201,7 +200,7 @@ public class TreasureChestBlock extends AbstractChestBlock<TreasureChestTileEnti
 
 	@Override
 	public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-		return new TreasureChestTileEntity(pos, state);
+		return new TreasureChestBlockEntity(pos, state);
 	}
 
 	@Override

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/ChestMimicBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/ChestMimicBlockEntity.java
@@ -6,13 +6,13 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class ChestMimicTileEntity extends BlockEntity
+public class ChestMimicBlockEntity extends BlockEntity
 {
-	public ChestMimicTileEntity(BlockPos pos, BlockState state) {
+	public ChestMimicBlockEntity(BlockPos pos, BlockState state) {
 		super(AetherTileEntityTypes.CHEST_MIMIC.get(), pos, state);
 	}
 
-	public ChestMimicTileEntity() {
+	public ChestMimicBlockEntity() {
 		super(AetherTileEntityTypes.CHEST_MIMIC.get(), BlockPos.ZERO, AetherBlocks.CHEST_MIMIC.get().defaultBlockState());
 	}
 }

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/ChestMimicTileEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/ChestMimicTileEntity.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.common.entity.tile;
 
+import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.gildedgames.aether.common.registry.AetherTileEntityTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -9,5 +10,9 @@ public class ChestMimicTileEntity extends BlockEntity
 {
 	public ChestMimicTileEntity(BlockPos pos, BlockState state) {
 		super(AetherTileEntityTypes.CHEST_MIMIC.get(), pos, state);
+	}
+
+	public ChestMimicTileEntity() {
+		super(AetherTileEntityTypes.CHEST_MIMIC.get(), BlockPos.ZERO, AetherBlocks.CHEST_MIMIC.get().defaultBlockState());
 	}
 }

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/SkyrootBedBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/SkyrootBedBlockEntity.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.common.entity.tile;
 
+import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.gildedgames.aether.common.registry.AetherTileEntityTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -9,6 +10,10 @@ public class SkyrootBedBlockEntity extends BlockEntity
 {
     public SkyrootBedBlockEntity(BlockPos pos, BlockState state) {
         super(AetherTileEntityTypes.SKYROOT_BED.get(), pos, state);
+    }
+
+    public SkyrootBedBlockEntity() {
+        super(AetherTileEntityTypes.SKYROOT_BED.get(), BlockPos.ZERO, AetherBlocks.SKYROOT_BED.get().defaultBlockState());
     }
 
 //    public ClientboundBlockEntityDataPacket getUpdatePacket() {

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestBlockEntity.java
@@ -8,7 +8,6 @@ import com.gildedgames.aether.core.registry.AetherDungeonTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.ContainerHelper;
@@ -19,8 +18,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.core.NonNullList;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -32,7 +29,7 @@ import net.minecraft.world.level.block.entity.LidBlockEntity;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 
 @OnlyIn(value = Dist.CLIENT, _interface = LidBlockEntity.class)
-public class TreasureChestTileEntity extends RandomizableContainerBlockEntity implements LidBlockEntity
+public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity implements LidBlockEntity
 {
     private NonNullList<ItemStack> items = NonNullList.withSize(27, ItemStack.EMPTY);
     protected float openness;
@@ -42,17 +39,17 @@ public class TreasureChestTileEntity extends RandomizableContainerBlockEntity im
     private boolean locked;
     private String kind;
 
-    protected TreasureChestTileEntity(BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
+    protected TreasureChestBlockEntity(BlockEntityType<?> tileEntityType, BlockPos pos, BlockState state) {
         super(tileEntityType, pos, state);
     }
 
-    public TreasureChestTileEntity(BlockPos pos, BlockState state) {
+    public TreasureChestBlockEntity(BlockPos pos, BlockState state) {
         this(AetherTileEntityTypes.TREASURE_CHEST.get(), pos, state);
         this.kind = AetherDungeonTypes.BRONZE.getRegistryName();
         this.locked = true;
     }
 
-    public TreasureChestTileEntity() {
+    public TreasureChestBlockEntity() {
         super(AetherTileEntityTypes.TREASURE_CHEST.get(), BlockPos.ZERO, AetherBlocks.TREASURE_CHEST.get().defaultBlockState());
     }
 

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestTileEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestTileEntity.java
@@ -2,6 +2,7 @@ package com.gildedgames.aether.common.entity.tile;
 
 import com.gildedgames.aether.common.block.dungeon.TreasureChestBlock;
 import com.gildedgames.aether.common.item.miscellaneous.DungeonKeyItem;
+import com.gildedgames.aether.common.registry.AetherBlocks;
 import com.gildedgames.aether.common.registry.AetherTileEntityTypes;
 import com.gildedgames.aether.core.registry.AetherDungeonTypes;
 import net.minecraft.core.BlockPos;
@@ -45,10 +46,14 @@ public class TreasureChestTileEntity extends RandomizableContainerBlockEntity im
         super(tileEntityType, pos, state);
     }
 
-    public TreasureChestTileEntity( BlockPos pos, BlockState state) {
+    public TreasureChestTileEntity(BlockPos pos, BlockState state) {
         this(AetherTileEntityTypes.TREASURE_CHEST.get(), pos, state);
         this.kind = AetherDungeonTypes.BRONZE.getRegistryName();
         this.locked = true;
+    }
+
+    public TreasureChestTileEntity() {
+        super(AetherTileEntityTypes.TREASURE_CHEST.get(), BlockPos.ZERO, AetherBlocks.TREASURE_CHEST.get().defaultBlockState());
     }
 
     @Override

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -4,13 +4,26 @@ import com.gildedgames.aether.client.registry.AetherRenderers;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.client.IItemRenderProperties;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public class EntityBlockItem extends BlockItem {
+    private Supplier<BlockEntity> blockEntity;
+
     public <B extends Block> EntityBlockItem(B block, Properties tab) {
         super(block, tab);
+    }
+
+    public EntityBlockItem setBlockEntity(Supplier<BlockEntity> blockEntity) {
+        this.blockEntity = blockEntity;
+        return this;
+    }
+
+    public BlockEntity getBlockEntity() {
+        return this.blockEntity.get();
     }
 
     @Override

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -11,15 +11,11 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class EntityBlockItem extends BlockItem {
-    private Supplier<BlockEntity> blockEntity;
+    private final Supplier<BlockEntity> blockEntity;
 
-    public <B extends Block> EntityBlockItem(B block, Properties tab) {
+    public <B extends Block> EntityBlockItem(B block, Supplier<BlockEntity> blockEntity, Properties tab) {
         super(block, tab);
-    }
-
-    public EntityBlockItem setBlockEntity(Supplier<BlockEntity> blockEntity) {
         this.blockEntity = blockEntity;
-        return this;
     }
 
     public BlockEntity getBlockEntity() {

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -1,22 +1,23 @@
 package com.gildedgames.aether.common.item.block;
 
-import com.gildedgames.aether.common.registry.AetherBlocks;
-import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.client.IItemRenderProperties;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
-public class SkyrootBedItem extends BlockItem {
-    public <B extends Block> SkyrootBedItem(B block, Properties tab) {
+public class EntityBlockItem extends BlockItem {
+    private Supplier<BlockEntityWithoutLevelRenderer> renderer;
+
+    public <B extends Block> EntityBlockItem(B block, Properties tab) {
         super(block, tab);
+    }
+
+    public EntityBlockItem setBEWLR(Supplier<BlockEntityWithoutLevelRenderer> renderer) {
+        this.renderer = renderer;
+        return this;
     }
 
     @Override
@@ -24,7 +25,7 @@ public class SkyrootBedItem extends BlockItem {
         consumer.accept(new IItemRenderProperties() {
             @Override
             public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
-                return AetherBlocks.AetherBEWLR;
+                return renderer.get();
             }
         });
     }

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -1,23 +1,16 @@
 package com.gildedgames.aether.common.item.block;
 
+import com.gildedgames.aether.client.registry.AetherRenderers;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.client.IItemRenderProperties;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class EntityBlockItem extends BlockItem {
-    private Supplier<BlockEntityWithoutLevelRenderer> renderer;
-
     public <B extends Block> EntityBlockItem(B block, Properties tab) {
         super(block, tab);
-    }
-
-    public EntityBlockItem setBEWLR(Supplier<BlockEntityWithoutLevelRenderer> renderer) {
-        this.renderer = renderer;
-        return this;
     }
 
     @Override
@@ -25,7 +18,7 @@ public class EntityBlockItem extends BlockItem {
         consumer.accept(new IItemRenderProperties() {
             @Override
             public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
-                return renderer.get();
+                return AetherRenderers.blockEntityWithoutLevelRenderer;
             }
         });
     }

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -13,6 +13,12 @@ import java.util.function.Consumer;
 
 public class EntityBlockItem extends BlockItem {
     private final LazyOptional<BlockEntity> blockEntity;
+    private static final IItemRenderProperties renderProperties = new IItemRenderProperties() {
+        @Override
+        public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
+            return AetherRenderers.blockEntityWithoutLevelRenderer;
+        }
+    };
 
     public <B extends Block> EntityBlockItem(B block, NonNullSupplier<BlockEntity> blockEntity, Properties tab) {
         super(block, tab);
@@ -25,11 +31,6 @@ public class EntityBlockItem extends BlockItem {
 
     @Override
     public void initializeClient(Consumer<IItemRenderProperties> consumer) {
-        consumer.accept(new IItemRenderProperties() {
-            @Override
-            public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
-                return AetherRenderers.blockEntityWithoutLevelRenderer;
-            }
-        });
+        consumer.accept(renderProperties);
     }
 }

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -6,20 +6,21 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.client.IItemRenderProperties;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.common.util.NonNullSupplier;
 
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class EntityBlockItem extends BlockItem {
-    private final Supplier<BlockEntity> blockEntity;
+    private final LazyOptional<BlockEntity> blockEntity;
 
-    public <B extends Block> EntityBlockItem(B block, Supplier<BlockEntity> blockEntity, Properties tab) {
+    public <B extends Block> EntityBlockItem(B block, NonNullSupplier<BlockEntity> blockEntity, Properties tab) {
         super(block, tab);
-        this.blockEntity = blockEntity;
+        this.blockEntity = LazyOptional.of(blockEntity);
     }
 
-    public BlockEntity getBlockEntity() {
-        return this.blockEntity.get();
+    public LazyOptional<BlockEntity> getBlockEntity() {
+        return this.blockEntity;
     }
 
     @Override

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
@@ -11,6 +11,9 @@ import com.gildedgames.aether.common.block.miscellaneous.AetherPortalBlock;
 import com.gildedgames.aether.common.block.natural.*;
 import com.gildedgames.aether.common.block.util.*;
 import com.gildedgames.aether.common.block.utility.*;
+import com.gildedgames.aether.common.entity.tile.ChestMimicTileEntity;
+import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
+import com.gildedgames.aether.common.entity.tile.TreasureChestTileEntity;
 import com.gildedgames.aether.common.item.block.BurnableBlockItem;
 import com.gildedgames.aether.common.item.block.EntityBlockItem;
 import com.gildedgames.aether.common.world.gen.tree.GoldenOakTree;
@@ -39,8 +42,6 @@ public class AetherBlocks
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, Aether.MODID);
 
     public static final RegistryObject<AetherPortalBlock> AETHER_PORTAL = BLOCKS.register("aether_portal", () -> new AetherPortalBlock(Block.Properties.copy(Blocks.NETHER_PORTAL)));
-
-    public static AetherBlockEntityWithoutLevelRenderer AetherBEWLR;
 
     public static final RegistryObject<Block> AETHER_GRASS_BLOCK = register("aether_grass_block", () -> new AetherGrassBlock(Block.Properties.of(Material.GRASS, MaterialColor.WARPED_WART_BLOCK).randomTicks().strength(0.6F).sound(SoundType.GRASS)));
     public static final RegistryObject<Block> ENCHANTED_AETHER_GRASS_BLOCK = register("enchanted_aether_grass_block", () -> new EnchantedAetherGrassBlock(Block.Properties.of(Material.GRASS, MaterialColor.GOLD).randomTicks().strength(0.6F).sound(SoundType.GRASS)));
@@ -294,9 +295,9 @@ public class AetherBlocks
             } else if (block == SKYROOT_SIGN.get()) {
                 return new SignItem((new Item.Properties()).stacksTo(16).tab(AetherItemGroups.AETHER_BLOCKS), SKYROOT_SIGN.get(), SKYROOT_WALL_SIGN.get());
             } else if (block == CHEST_MIMIC.get()) {
-                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
+                return new EntityBlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(ChestMimicTileEntity::new);
             } else if (block == TREASURE_CHEST.get()) {
-                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
+                return new EntityBlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(TreasureChestTileEntity::new);
             } else if (block == SKYROOT_PLANKS.get()
                     || block == SKYROOT_FENCE_GATE.get()
                     || block == SKYROOT_FENCE.get()
@@ -305,7 +306,7 @@ public class AetherBlocks
             } else if (block == SUN_ALTAR.get()) {
                 return new BlockItem(block, new Item.Properties().fireResistant().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_BED.get()) {
-                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS));
+                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(SkyrootBedBlockEntity::new);
             } else {
                 return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             }

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
@@ -2,7 +2,6 @@ package com.gildedgames.aether.common.registry;
 
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.registry.AetherParticleTypes;
-import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.common.block.construction.*;
 import com.gildedgames.aether.common.block.dungeon.ChestMimicBlock;
 import com.gildedgames.aether.common.block.dungeon.TrappedBlock;
@@ -11,9 +10,9 @@ import com.gildedgames.aether.common.block.miscellaneous.AetherPortalBlock;
 import com.gildedgames.aether.common.block.natural.*;
 import com.gildedgames.aether.common.block.util.*;
 import com.gildedgames.aether.common.block.utility.*;
-import com.gildedgames.aether.common.entity.tile.ChestMimicTileEntity;
+import com.gildedgames.aether.common.entity.tile.ChestMimicBlockEntity;
 import com.gildedgames.aether.common.entity.tile.SkyrootBedBlockEntity;
-import com.gildedgames.aether.common.entity.tile.TreasureChestTileEntity;
+import com.gildedgames.aether.common.entity.tile.TreasureChestBlockEntity;
 import com.gildedgames.aether.common.item.block.BurnableBlockItem;
 import com.gildedgames.aether.common.item.block.EntityBlockItem;
 import com.gildedgames.aether.common.world.gen.tree.GoldenOakTree;
@@ -295,9 +294,9 @@ public class AetherBlocks
             } else if (block == SKYROOT_SIGN.get()) {
                 return new SignItem((new Item.Properties()).stacksTo(16).tab(AetherItemGroups.AETHER_BLOCKS), SKYROOT_SIGN.get(), SKYROOT_WALL_SIGN.get());
             } else if (block == CHEST_MIMIC.get()) {
-                return new EntityBlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(ChestMimicTileEntity::new);
+                return new EntityBlockItem(block, ChestMimicBlockEntity::new, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == TREASURE_CHEST.get()) {
-                return new EntityBlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(TreasureChestTileEntity::new);
+                return new EntityBlockItem(block, TreasureChestBlockEntity::new, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_PLANKS.get()
                     || block == SKYROOT_FENCE_GATE.get()
                     || block == SKYROOT_FENCE.get()
@@ -306,7 +305,7 @@ public class AetherBlocks
             } else if (block == SUN_ALTAR.get()) {
                 return new BlockItem(block, new Item.Properties().fireResistant().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_BED.get()) {
-                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)).setBlockEntity(SkyrootBedBlockEntity::new);
+                return new EntityBlockItem(block, SkyrootBedBlockEntity::new, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS));
             } else {
                 return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             }

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
@@ -2,7 +2,6 @@ package com.gildedgames.aether.common.registry;
 
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.registry.AetherParticleTypes;
-import com.gildedgames.aether.client.registry.AetherRenderers;
 import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.common.block.construction.*;
 import com.gildedgames.aether.common.block.dungeon.ChestMimicBlock;
@@ -295,10 +294,9 @@ public class AetherBlocks
             } else if (block == SKYROOT_SIGN.get()) {
                 return new SignItem((new Item.Properties()).stacksTo(16).tab(AetherItemGroups.AETHER_BLOCKS), SKYROOT_SIGN.get(), SKYROOT_WALL_SIGN.get());
             } else if (block == CHEST_MIMIC.get()) {
-                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)/*.setISTER(() -> AetherRendering::chestMimicRenderer)*/);
-            } // SEE: https://mcforge.readthedocs.io/en/1.18.x/rendering/bewlr/#using-blockentitywithoutlevelrenderer
-            else if (block == TREASURE_CHEST.get()) {
-                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS)/*.setISTER(() -> AetherRendering::treasureChestRenderer)*/);
+                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
+            } else if (block == TREASURE_CHEST.get()) {
+                return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_PLANKS.get()
                     || block == SKYROOT_FENCE_GATE.get()
                     || block == SKYROOT_FENCE.get()
@@ -307,7 +305,7 @@ public class AetherBlocks
             } else if (block == SUN_ALTAR.get()) {
                 return new BlockItem(block, new Item.Properties().fireResistant().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_BED.get()) {
-                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)).setBEWLR(AetherRenderers::skyrootBedRenderer);
+                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS));
             } else {
                 return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             }

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherBlocks.java
@@ -2,6 +2,7 @@ package com.gildedgames.aether.common.registry;
 
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.client.registry.AetherParticleTypes;
+import com.gildedgames.aether.client.registry.AetherRenderers;
 import com.gildedgames.aether.client.renderer.tile.AetherBlockEntityWithoutLevelRenderer;
 import com.gildedgames.aether.common.block.construction.*;
 import com.gildedgames.aether.common.block.dungeon.ChestMimicBlock;
@@ -12,10 +13,9 @@ import com.gildedgames.aether.common.block.natural.*;
 import com.gildedgames.aether.common.block.util.*;
 import com.gildedgames.aether.common.block.utility.*;
 import com.gildedgames.aether.common.item.block.BurnableBlockItem;
-import com.gildedgames.aether.common.item.block.SkyrootBedItem;
+import com.gildedgames.aether.common.item.block.EntityBlockItem;
 import com.gildedgames.aether.common.world.gen.tree.GoldenOakTree;
 import com.gildedgames.aether.common.world.gen.tree.SkyrootTree;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.effect.MobEffects;
@@ -35,7 +35,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class AetherBlocks {
+public class AetherBlocks
+{
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, Aether.MODID);
 
     public static final RegistryObject<AetherPortalBlock> AETHER_PORTAL = BLOCKS.register("aether_portal", () -> new AetherPortalBlock(Block.Properties.copy(Blocks.NETHER_PORTAL)));
@@ -306,15 +307,11 @@ public class AetherBlocks {
             } else if (block == SUN_ALTAR.get()) {
                 return new BlockItem(block, new Item.Properties().fireResistant().tab(AetherItemGroups.AETHER_BLOCKS));
             } else if (block == SKYROOT_BED.get()) {
-                return new SkyrootBedItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)/*.setISTER(() -> AetherRendering::skyrootBedRenderer)*/);
+                return new EntityBlockItem(block, new Item.Properties().stacksTo(1).tab(AetherItemGroups.AETHER_BLOCKS)).setBEWLR(AetherRenderers::skyrootBedRenderer);
             } else {
                 return new BlockItem(block, new Item.Properties().tab(AetherItemGroups.AETHER_BLOCKS));
             }
         };
-    }
-
-    public static void initBEWLR() {
-        AetherBEWLR = new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
     }
 
     private static boolean never(BlockState p_test_1_, BlockGetter p_test_2_, BlockPos p_test_3_) {

--- a/src/main/java/com/gildedgames/aether/common/registry/AetherTileEntityTypes.java
+++ b/src/main/java/com/gildedgames/aether/common/registry/AetherTileEntityTypes.java
@@ -20,10 +20,10 @@ public class AetherTileEntityTypes
 			new BlockEntityType(FreezerTileEntity::new, Sets.newHashSet(AetherBlocks.FREEZER.get()), null));
 	public static final RegistryObject<BlockEntityType<IncubatorTileEntity>> INCUBATOR = TILE_ENTITIES.register("incubator", () ->
 			new BlockEntityType(IncubatorTileEntity::new, Sets.newHashSet(AetherBlocks.INCUBATOR.get()), null));
-	public static final RegistryObject<BlockEntityType<ChestMimicTileEntity>> CHEST_MIMIC = TILE_ENTITIES.register("chest_mimic", () ->
-			new BlockEntityType(ChestMimicTileEntity::new, Sets.newHashSet(AetherBlocks.CHEST_MIMIC.get()), null));
-	public static final RegistryObject<BlockEntityType<TreasureChestTileEntity>> TREASURE_CHEST = TILE_ENTITIES.register("treasure_chest", () ->
-			new BlockEntityType(TreasureChestTileEntity::new, Sets.newHashSet(AetherBlocks.TREASURE_CHEST.get()), null));
+	public static final RegistryObject<BlockEntityType<ChestMimicBlockEntity>> CHEST_MIMIC = TILE_ENTITIES.register("chest_mimic", () ->
+			new BlockEntityType(ChestMimicBlockEntity::new, Sets.newHashSet(AetherBlocks.CHEST_MIMIC.get()), null));
+	public static final RegistryObject<BlockEntityType<TreasureChestBlockEntity>> TREASURE_CHEST = TILE_ENTITIES.register("treasure_chest", () ->
+			new BlockEntityType(TreasureChestBlockEntity::new, Sets.newHashSet(AetherBlocks.TREASURE_CHEST.get()), null));
 	public static final RegistryObject<BlockEntityType<SkyrootBedBlockEntity>> SKYROOT_BED = TILE_ENTITIES.register("skyroot_bed", () ->
 			new BlockEntityType(SkyrootBedBlockEntity::new, Sets.newHashSet(AetherBlocks.SKYROOT_BED.get()), null));
 	public static final RegistryObject<BlockEntityType<SkyrootSignTileEntity>> SKYROOT_SIGN = TILE_ENTITIES.register("custom_sign", () ->


### PR DESCRIPTION
Simplified how we register BEWLRs. This should ideally mean we don't have to change the AetherBlockEntityWithoutLevelRenderer every time we add a new BEWLR for an item, we can just register in the same place as the block item itself by passing a block entity as an argument.