### PR TITLE
Fix: Fixed a crash on the server caused by CapeEntity.

### DIFF
--- a/src/main/java/com/gildedgames/aether/core/capability/capabilities/cape/CapeEntity.java
+++ b/src/main/java/com/gildedgames/aether/core/capability/capabilities/cape/CapeEntity.java
@@ -89,7 +89,7 @@ public class CapeEntity implements ICapeEntity
 
     private void tickPassenger(Entity passenger) {
         if (!passenger.isRemoved()) {
-            if ((passenger.level instanceof ClientLevel clientLevel && clientLevel.tickingEntities.contains(passenger)) || (passenger.level instanceof ServerLevel serverLevel && serverLevel.entityTickList.contains(passenger))) {
+            if ((passenger.level.isClientSide && passenger.level instanceof ClientLevel clientLevel && clientLevel.tickingEntities.contains(passenger)) || (passenger.level instanceof ServerLevel serverLevel && serverLevel.entityTickList.contains(passenger))) {
                 this.rideTick();
             }
         }


### PR DESCRIPTION
`OnlyIn`  annotations are pain.

Added a level.isClientSide check before checking for the ClientWorld class.