### PR TITLE
Enhancement: Zephyr polishing

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/particle/WhiteSmokeParticle.java
+++ b/src/main/java/com/gildedgames/aether/client/particle/WhiteSmokeParticle.java
@@ -6,7 +6,7 @@ import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-//Subclass of SmokeParticle to make white particles.
+//Subclass of SmokeParticle to make white particles. TODO: Is this particle necessary?
 public class WhiteSmokeParticle extends SmokeParticle {
     protected WhiteSmokeParticle(ClientLevel p_i232425_1_, double p_i232425_2_, double p_i232425_4_, double p_i232425_6_, double p_i232425_8_, double p_i232425_10_, double p_i232425_12_, float p_i232425_14_, SpriteSet p_i232425_15_) {
         super(p_i232425_1_, p_i232425_2_, p_i232425_4_, p_i232425_6_, p_i232425_8_, p_i232425_10_, p_i232425_12_, p_i232425_14_, p_i232425_15_);

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherParticleTypes.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherParticleTypes.java
@@ -5,6 +5,7 @@ import com.gildedgames.aether.client.particle.*;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.particle.SnowflakeParticle;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraftforge.api.distmarker.Dist;
@@ -28,6 +29,7 @@ public class AetherParticleTypes
 	public static final RegistryObject<SimpleParticleType> FROZEN = PARTICLES.register("frozen", () -> new SimpleParticleType(false));
 	public static final RegistryObject<SimpleParticleType> PASSIVE_WHIRLWIND = PARTICLES.register("passive_whirlwind", () -> new SimpleParticleType(false));
 	public static final RegistryObject<SimpleParticleType> EVIL_WHIRLWIND = PARTICLES.register("evil_whirlwind", () -> new SimpleParticleType(false));
+	public static final RegistryObject<SimpleParticleType> ZEPHYR_SNOWFLAKE = PARTICLES.register("zephyr_snowflake", ()-> new SimpleParticleType(false));
 
 	@SubscribeEvent
 	@OnlyIn(Dist.CLIENT)
@@ -41,5 +43,6 @@ public class AetherParticleTypes
 		particleManager.register(FROZEN.get(), FrozenParticle.Factory::new);
 		particleManager.register(PASSIVE_WHIRLWIND.get(), PassiveWhirlyParticle.Factory::new);
 		particleManager.register(EVIL_WHIRLWIND.get(), EvilWhirlyParticle.Factory::new);
+		particleManager.register(ZEPHYR_SNOWFLAKE.get(), SnowflakeParticle.Provider::new);
 	}
 }

--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -92,7 +92,7 @@ public class AetherRenderers {
         event.registerEntityRenderer(AetherEntityTypes.FLOATING_BLOCK.get(), FloatingBlockRenderer::new);
         event.registerEntityRenderer(AetherEntityTypes.TNT_PRESENT.get(), TNTPresentRenderer::new);
 
-        event.registerEntityRenderer(AetherEntityTypes.ZEPHYR_SNOWBALL.get(), ThrownItemRenderer::new);
+        event.registerEntityRenderer(AetherEntityTypes.ZEPHYR_SNOWBALL.get(), (context) -> new ThrownItemRenderer<>(context, 3.0F, true));
         event.registerEntityRenderer(AetherEntityTypes.CLOUD_CRYSTAL.get(), IceCrystalRenderer::new);
         event.registerEntityRenderer(AetherEntityTypes.GOLDEN_DART.get(), GoldenDartRenderer::new);
         event.registerEntityRenderer(AetherEntityTypes.POISON_DART.get(), PoisonDartRenderer::new);

--- a/src/main/java/com/gildedgames/aether/common/entity/monster/ZephyrEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/monster/ZephyrEntity.java
@@ -32,15 +32,10 @@ import java.util.Random;
 
 public class ZephyrEntity extends FlyingMob implements Enemy {
 	public static final EntityDataAccessor<Integer> ATTACK_CHARGE = SynchedEntityData.defineId(ZephyrEntity.class, EntityDataSerializers.INT);
-	public static final EntityDataAccessor<Boolean> IS_ATTACKING = SynchedEntityData.defineId(ZephyrEntity.class, EntityDataSerializers.BOOLEAN);
 
 	public ZephyrEntity(EntityType<? extends ZephyrEntity> type, Level worldIn) {
 		super(type, worldIn);
 		this.moveControl = new ZephyrEntity.MoveHelperController(this);
-	}
-
-	public ZephyrEntity(Level worldIn) {
-		this(AetherEntityTypes.ZEPHYR.get(), worldIn);
 	}
 
 	@Override
@@ -61,15 +56,10 @@ public class ZephyrEntity extends FlyingMob implements Enemy {
 	protected void defineSynchedData() {
 		super.defineSynchedData();
 		this.entityData.define(ATTACK_CHARGE, 0);
-		this.entityData.define(IS_ATTACKING, false);
 	}
 
 	public int getAttackCharge() {
 		return this.entityData.get(ATTACK_CHARGE);
-	}
-	
-	public boolean isAttacking() {
-		return this.entityData.get(IS_ATTACKING);
 	}
 
 	/**
@@ -78,14 +68,7 @@ public class ZephyrEntity extends FlyingMob implements Enemy {
 	 * zephyr begins to wind up for an attack.
 	 */
 	public void setAttackCharge(int attackTimer) {
-		if (attackTimer > 0) {
-			this.entityData.set(ATTACK_CHARGE, attackTimer);
-			this.entityData.set(IS_ATTACKING, true);
-		}
-		else {
-			this.entityData.set(ATTACK_CHARGE, 0);
-			this.entityData.set(IS_ATTACKING, false);
-		}
+		this.entityData.set(ATTACK_CHARGE, Math.max(attackTimer, 0));
 	}
 
 	@Override

--- a/src/main/java/com/gildedgames/aether/common/entity/monster/ZephyrEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/monster/ZephyrEntity.java
@@ -1,6 +1,5 @@
 package com.gildedgames.aether.common.entity.monster;
 
-import com.gildedgames.aether.common.registry.AetherEntityTypes;
 import com.gildedgames.aether.common.entity.projectile.ZephyrSnowballEntity;
 import com.gildedgames.aether.client.registry.AetherSoundEvents;
 import net.minecraft.world.entity.EntityType;

--- a/src/main/java/com/gildedgames/aether/common/entity/projectile/ZephyrSnowballEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/projectile/ZephyrSnowballEntity.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.common.entity.projectile;
 
+import com.gildedgames.aether.client.registry.AetherParticleTypes;
 import com.gildedgames.aether.common.registry.AetherEntityTypes;
 import com.gildedgames.aether.common.registry.AetherItems;
 
@@ -140,7 +141,7 @@ public class ZephyrSnowballEntity extends Fireball implements ItemSupplier {
 
 	@Override
 	protected ParticleOptions getTrailParticle() {
-		return null;
+		return AetherParticleTypes.ZEPHYR_SNOWFLAKE.get();
 	}
 
 	@Override

--- a/src/main/java/com/gildedgames/aether/core/network/AetherPacketHandler.java
+++ b/src/main/java/com/gildedgames/aether/core/network/AetherPacketHandler.java
@@ -39,6 +39,7 @@ public class AetherPacketHandler
 		register(ResetMaxUpStepPacket.class, ResetMaxUpStepPacket::decode);
 		register(ServerTimePacket.class, ServerTimePacket::decode);
 		register(SetVehiclePacket.class, SetVehiclePacket::decode);
+		register(ZephyrSnowballHitPacket.class, ZephyrSnowballHitPacket::decode);
 
 		// SERVER
 		register(ExtendedAttackPacket.class, ExtendedAttackPacket::decode);

--- a/src/main/java/com/gildedgames/aether/core/network/packet/client/ZephyrSnowballHitPacket.java
+++ b/src/main/java/com/gildedgames/aether/core/network/packet/client/ZephyrSnowballHitPacket.java
@@ -1,0 +1,45 @@
+package com.gildedgames.aether.core.network.packet.client;
+
+import com.gildedgames.aether.core.network.IAetherPacket;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * This packet is used to move the player on the client when they are hit by a ZephyrSnowBallEntity on the server.
+ */
+public class ZephyrSnowballHitPacket extends IAetherPacket.AetherPacket {
+    private final int entityID;
+    private final double xSpeed;
+    private final double zSpeed;
+    public ZephyrSnowballHitPacket(int id, double x, double z) {
+        this.entityID = id;
+        this.xSpeed = x;
+        this.zSpeed = z;
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeInt(this.entityID);
+        buf.writeDouble(this.xSpeed);
+        buf.writeDouble(this.zSpeed);
+    }
+
+    public static ZephyrSnowballHitPacket decode(FriendlyByteBuf buf) {
+        int id = buf.readInt();
+        double x = buf.readDouble();
+        double z = buf.readDouble();
+        return new ZephyrSnowballHitPacket(id, x, z);
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (Minecraft.getInstance().player != null && Minecraft.getInstance().level != null && Minecraft.getInstance().player.level.getEntity(this.entityID) instanceof LocalPlayer localPlayer) {
+            if (!localPlayer.isBlocking()) {
+                localPlayer.setDeltaMovement(localPlayer.getDeltaMovement().x, localPlayer.getDeltaMovement().y + 0.5, localPlayer.getDeltaMovement().z);
+            }
+            localPlayer.setDeltaMovement(localPlayer.getDeltaMovement().x + (this.xSpeed * 1.5F), localPlayer.getDeltaMovement().y, localPlayer.getDeltaMovement().z + (this.zSpeed * 1.5F));
+        }
+    }
+}

--- a/src/main/resources/assets/aether/particles/zephyr_snowflake.json
+++ b/src/main/resources/assets/aether/particles/zephyr_snowflake.json
@@ -1,0 +1,12 @@
+{
+  "textures": [
+    "minecraft:generic_7",
+    "minecraft:generic_6",
+    "minecraft:generic_5",
+    "minecraft:generic_4",
+    "minecraft:generic_3",
+    "minecraft:generic_2",
+    "minecraft:generic_1",
+    "minecraft:generic_0"
+  ]
+}


### PR DESCRIPTION
This PR takes care of most of the remaining issues with Zephyrs.
- Made zephyr snowballs the same size as ghast fireballs.
- Removed some unnecessary code in ZephyrEntity.
- Created ZephyrSnowballHitPacket to handle player movement when they hit.
- Added a placeholder snowflake particle for the zephyr snowball.

Closes #216 