### PR TITLE
Fix: The world tick listener now checks against the minimum build height.

### DIFF
--- a/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
+++ b/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
@@ -146,7 +146,7 @@ public class DimensionListener
                     if (!AetherConfig.COMMON.disable_falling_to_overworld.get()) {
                         for (Entity entity : world.getEntities(EntityTypeTest.forClass(Entity.class), Objects::nonNull)) {
                             if (entity.getY() <= world.getMinBuildHeight() && !entity.isPassenger()) {
-                                if(!(entity instanceof Player player && player.getAbilities().flying)) {
+                                if (!(entity instanceof Player player && player.getAbilities().flying)) {
                                     fallFromAether(entity);
                                 }
                             }

--- a/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
+++ b/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
@@ -145,7 +145,7 @@ public class DimensionListener
                 if (event.phase == TickEvent.Phase.END) {
                     if (!AetherConfig.COMMON.disable_falling_to_overworld.get()) {
                         for (Entity entity : world.getEntities(EntityTypeTest.forClass(Entity.class), Objects::nonNull)) {
-                            if (entity.getY() <= 0 && !entity.isPassenger()) {
+                            if (entity.getY() <= world.getMinBuildHeight() && !entity.isPassenger()) {
                                 fallFromAether(entity);
                             }
                         }

--- a/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
+++ b/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
@@ -146,6 +146,9 @@ public class DimensionListener
                     if (!AetherConfig.COMMON.disable_falling_to_overworld.get()) {
                         for (Entity entity : world.getEntities(EntityTypeTest.forClass(Entity.class), Objects::nonNull)) {
                             if (entity.getY() <= world.getMinBuildHeight() && !entity.isPassenger()) {
+                                if(entity instanceof Player player && (player.getAbilities().flying)) {
+                                    continue;
+                                }
                                 fallFromAether(entity);
                             }
                         }

--- a/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
+++ b/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
@@ -146,10 +146,9 @@ public class DimensionListener
                     if (!AetherConfig.COMMON.disable_falling_to_overworld.get()) {
                         for (Entity entity : world.getEntities(EntityTypeTest.forClass(Entity.class), Objects::nonNull)) {
                             if (entity.getY() <= world.getMinBuildHeight() && !entity.isPassenger()) {
-                                if(entity instanceof Player player && (player.getAbilities().flying)) {
-                                    continue;
+                                if(!(entity instanceof Player player && player.getAbilities().flying)) {
+                                    fallFromAether(entity);
                                 }
-                                fallFromAether(entity);
                             }
                         }
                     }


### PR DESCRIPTION
Players now fall out of the Aether at the dimension type's minimum build height instead of y=0. Players flying through creative or spectator can't fall out of the Aether.
Closes #394 