### PR TITLE
Updated saving data methods for some block entities.

### DIFF
--- a/src/main/java/com/gildedgames/aether/common/entity/tile/IncubatorTileEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/IncubatorTileEntity.java
@@ -225,13 +225,12 @@ public class IncubatorTileEntity extends BaseContainerBlockEntity implements Wor
 	}
 	
 	@Override
-	public CompoundTag save(CompoundTag compound) {
-		super.save(compound);
+	public void saveAdditional(CompoundTag compound) {
+		super.saveAdditional(compound);
 		compound.putInt("BurnTime", this.powerRemaining);
 		compound.putInt("CookTime", this.progress);
 		compound.putInt("CookTimeTotal", this.ticksRequired);
 		ContainerHelper.saveAllItems(compound, this.items);
-		return compound;
 	}
 	
 	net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers =

--- a/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/common/entity/tile/TreasureChestBlockEntity.java
@@ -202,7 +202,7 @@ public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity i
 
     @Override
     public CompoundTag getUpdateTag() {
-        return this.save(new CompoundTag());
+        return this.saveWithoutMetadata();
     }
 
     @Override
@@ -222,13 +222,12 @@ public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity i
     }
 
     @Override
-    public CompoundTag save(CompoundTag compound) {
-        super.save(compound);
+    public void saveAdditional(CompoundTag compound) {
+        super.saveAdditional(compound);
         compound.putBoolean("Locked", this.getLocked());
         compound.putString("Kind", this.getKind());
         if (!this.trySaveLootTable(compound)) {
             ContainerHelper.saveAllItems(compound, this.items);
         }
-        return compound;
     }
 }


### PR DESCRIPTION
`BlockEntity.save(CompoundNBT)` no longer exists. TreasureChestBlockEntity and IncubatorTileEntity now override saveAdditional instead, ensuring that the mod is compatible with the latest Forge version.