### PR TITLE
Fixed advancement toasts to play the sound on all Aether advancements.

### DIFF
--- a/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
+++ b/src/main/java/com/gildedgames/aether/core/mixin/client/AdvancementToastMixin.java
@@ -32,8 +32,7 @@ public class AdvancementToastMixin
     @Inject(at = @At("HEAD"), method = "render")
     private void render(PoseStack poseStack, ToastComponent toastComponent, long timeSinceLastVisible, CallbackInfoReturnable<Toast.Visibility> cir) {
         if (!this.playedSound) {
-            ResourceLocation enterAether = new ResourceLocation(Aether.MODID, "enter_aether");
-            if (this.advancement.getId().equals(enterAether) || (this.advancement.getParent() != null && this.advancement.getParent().getId().equals(enterAether))) {
+            if (this.checkRoot()) {
                 this.playedSound = true;
                 switch (this.advancement.getId().getPath()) {
                     case "like_a_bossaru" -> toastComponent.getMinecraft().getSoundManager().play(SimpleSoundInstance.forUI(AetherSoundEvents.UI_TOAST_AETHER_BRONZE.get(), 1.0F, 1.0F));
@@ -43,4 +42,19 @@ public class AdvancementToastMixin
             }
         }
     }
+
+    /**
+     * Checks all the way up to the root of the advancement tree to determine if it's an Aether advancement.
+     */
+    private boolean checkRoot() {
+        ResourceLocation enterAether = new ResourceLocation(Aether.MODID, "enter_aether");
+        for (Advancement advancement = this.advancement; advancement != null; advancement = advancement.getParent()) {
+            if (advancement.getId().equals(enterAether)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
 }


### PR DESCRIPTION
This PR adds a helper method to `AdvancementToastMixin` to find the root for the given advancement, rather than just checking against the parent. This allows the advancement toast to properly check if the advancement is in the Aether tab.
Closes #321 