### PR TITLE
fix: Moved render properties out of EntityBlockItem so it's not loaded server-side.

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
+++ b/src/main/java/com/gildedgames/aether/client/registry/AetherRenderers.java
@@ -32,6 +32,7 @@ import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.IItemRenderProperties;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -44,6 +45,13 @@ import java.util.function.Supplier;
 public class AetherRenderers {
     public static final Lazy<BlockEntityWithoutLevelRenderer> blockEntityWithoutLevelRenderer = () ->
             new AetherBlockEntityWithoutLevelRenderer(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
+
+    public static final IItemRenderProperties entityBlockItemRenderProperties = new IItemRenderProperties() {
+        @Override
+        public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
+            return AetherRenderers.blockEntityWithoutLevelRenderer.get();
+        }
+    };
 
     public static void registerBlockRenderLayers() {
         RenderType cutout = RenderType.cutout();

--- a/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/common/item/block/EntityBlockItem.java
@@ -1,7 +1,6 @@
 package com.gildedgames.aether.common.item.block;
 
 import com.gildedgames.aether.client.registry.AetherRenderers;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -13,12 +12,6 @@ import java.util.function.Consumer;
 
 public class EntityBlockItem extends BlockItem {
     private final LazyOptional<BlockEntity> blockEntity;
-    private static final IItemRenderProperties renderProperties = new IItemRenderProperties() {
-        @Override
-        public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
-            return AetherRenderers.blockEntityWithoutLevelRenderer.get();
-        }
-    };
 
     public <B extends Block> EntityBlockItem(B block, NonNullSupplier<BlockEntity> blockEntity, Properties tab) {
         super(block, tab);
@@ -31,6 +24,6 @@ public class EntityBlockItem extends BlockItem {
 
     @Override
     public void initializeClient(Consumer<IItemRenderProperties> consumer) {
-        consumer.accept(renderProperties);
+        consumer.accept(AetherRenderers.entityBlockItemRenderProperties);
     }
 }


### PR DESCRIPTION
This fixes the server crash issue so ANTS can load and is also technically a resolution for #460.