### PR TITLE
fix: Time no longer breaks and follows the Overworld's cycle when first joining a server in the Aether.

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/event/hooks/CapabilityClientHooks.java
+++ b/src/main/java/com/gildedgames/aether/client/event/hooks/CapabilityClientHooks.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.client.event.hooks;
 
+import com.gildedgames.aether.common.event.hooks.CapabilityHooks;
 import com.gildedgames.aether.core.capability.player.AetherPlayer;
 import com.gildedgames.aether.core.network.AetherPacketHandler;
 import com.gildedgames.aether.core.network.packet.server.HittingPacket;
@@ -48,4 +49,11 @@ public class CapabilityClientHooks {
         }
     }
 
+    public static class AetherTimeHooks {
+        public static void setClientWorld() {
+            if (CapabilityHooks.AetherTimeHooks.world == null) {
+                CapabilityHooks.AetherTimeHooks.world = Minecraft.getInstance().level;
+            }
+        }
+    }
 }

--- a/src/main/java/com/gildedgames/aether/client/event/listeners/capability/AetherTimeClientListener.java
+++ b/src/main/java/com/gildedgames/aether/client/event/listeners/capability/AetherTimeClientListener.java
@@ -1,0 +1,15 @@
+package com.gildedgames.aether.client.event.listeners.capability;
+
+import com.gildedgames.aether.client.event.hooks.CapabilityClientHooks;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(Dist.CLIENT)
+public class AetherTimeClientListener {
+    @SubscribeEvent
+    public static void onTick(TickEvent.ClientTickEvent event) {
+        CapabilityClientHooks.AetherTimeHooks.setClientWorld();
+    }
+}

--- a/src/main/java/com/gildedgames/aether/common/event/hooks/DimensionHooks.java
+++ b/src/main/java/com/gildedgames/aether/common/event/hooks/DimensionHooks.java
@@ -180,8 +180,9 @@ public class DimensionHooks {
         }
     }
 
-    public static void syncTrackersFromServer(Level level, Entity entity) {
-        if (!level.isClientSide() && level instanceof ServerLevel serverLevel && entity instanceof Player) {
+    public static void syncTrackersFromServer(Player player) {
+        Level level = player.getLevel();
+        if (!level.isClientSide() && level instanceof ServerLevel serverLevel) {
             for (ServerLevel dimension : serverLevel.getServer().getAllLevels()) {
                 for (TagKey<DimensionType> tag : LevelUtil.getTags()) {
                     LevelUtil.syncTrackerFromServer(dimension, tag);

--- a/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
+++ b/src/main/java/com/gildedgames/aether/common/event/listeners/DimensionListener.java
@@ -11,8 +11,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -65,9 +65,8 @@ public class DimensionListener {
     }
 
     @SubscribeEvent
-    public static void onEntityJoin(EntityJoinWorldEvent event) {
-        Level level = event.getWorld();
-        Entity entity = event.getEntity();
-        DimensionHooks.syncTrackersFromServer(level, entity);
+    public static void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
+        Player player = event.getPlayer();
+        DimensionHooks.syncTrackersFromServer(player);
     }
 }

--- a/src/main/java/com/gildedgames/aether/core/capability/time/AetherTimeCapability.java
+++ b/src/main/java/com/gildedgames/aether/core/capability/time/AetherTimeCapability.java
@@ -12,8 +12,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 
-import java.util.stream.Collectors;
-
 /**
  * Capability class to handle the Aether's custom day/night cycle.
  * This class makes the day/night cycle longer depending on the time factor, and handles eternal day.
@@ -87,9 +85,7 @@ public class AetherTimeCapability implements AetherTime {
 
     private void wakeUpAllPlayers(ServerLevel level) {
         level.sleepStatus.removeAllSleepers();
-        level.players().stream().filter(LivingEntity::isSleeping).collect(Collectors.toList()).forEach((p_184116_) -> {
-            p_184116_.stopSleepInBed(false, false);
-        });
+        level.players().stream().filter(LivingEntity::isSleeping).toList().forEach((p_184116_) -> p_184116_.stopSleepInBed(false, false));
     }
 
     /**


### PR DESCRIPTION
- [x] Closes #565.