### PR TITLE
refactor: Use suppliers to keep track of moa types

### DIFF
--- a/src/main/java/com/gildedgames/aether/entity/monster/Cockatrice.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/Cockatrice.java
@@ -212,11 +212,6 @@ public class Cockatrice extends Monster implements RangedAttackMob, WingedBird, 
     }
 
     @Override
-    protected float getSoundVolume() {
-        return 0.25F;
-    }
-
-    @Override
     protected int calculateFallDamage(float distance, float damageMultiplier) {
         return 0;
     }

--- a/src/main/java/com/gildedgames/aether/entity/passive/Moa.java
+++ b/src/main/java/com/gildedgames/aether/entity/passive/Moa.java
@@ -421,11 +421,6 @@ public class Moa extends MountableAnimal implements WingedBird {
 	}
 
 	@Override
-	protected float getSoundVolume() {
-		return 0.25F;
-	}
-
-	@Override
 	public boolean isFood(@Nonnull ItemStack stack) {
 		return false;
 	}

--- a/src/main/java/com/gildedgames/aether/item/miscellaneous/MoaEggItem.java
+++ b/src/main/java/com/gildedgames/aether/item/miscellaneous/MoaEggItem.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Maps;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
@@ -43,13 +44,19 @@ import java.util.function.Supplier;
 
 public class MoaEggItem extends Item
 {
-    private static final Map<RegistryObject<MoaType>, MoaEggItem> BY_ID = Maps.newIdentityHashMap();
-    private final Supplier<MoaType> moaType;
+    private static final Map<Supplier<? extends MoaType>, MoaEggItem> BY_ID = Maps.newIdentityHashMap();
+    private final Supplier<? extends MoaType> moaType;
+    private final ResourceLocation moaTypeId;
     private final int color;
 
-    public MoaEggItem(RegistryObject<MoaType> moaType, int shellColor, Properties properties) {
+    public MoaEggItem(RegistryObject<? extends MoaType> moaType, int shellColor, Properties properties) {
+        this(moaType, moaType.getId(), shellColor, properties);
+    }
+
+    public MoaEggItem(Supplier<? extends MoaType> moaType, ResourceLocation moaTypeId, int shellColor, Properties properties) {
         super(properties);
         this.moaType = moaType;
+        this.moaTypeId = moaTypeId;
         this.color = shellColor;
         BY_ID.put(moaType, this);
     }
@@ -73,7 +80,7 @@ public class MoaEggItem extends Item
                         BaseSpawner basespawner = spawnerBlockEntity.getSpawner();
                         EntityType<Moa> entityType1 = AetherEntityTypes.MOA.get();
                         basespawner.setEntityId(entityType1);
-                        basespawner.nextSpawnData.getEntityToSpawn().putString("MoaType", this.getMoaType().toString());
+                        basespawner.nextSpawnData.getEntityToSpawn().putString("MoaType", this.getMoaTypeId().toString());
                         basespawner.nextSpawnData.getEntityToSpawn().putBoolean("PlayerGrown", true);
                         blockentity.setChanged();
                         level.sendBlockUpdated(blockPos, blockState, blockState, 3);
@@ -89,7 +96,7 @@ public class MoaEggItem extends Item
                     blockPos1 = blockPos.relative(direction);
                 }
 
-                ItemStack spawnStack = this.getStackWithTags(itemStack, false, this.getMoaType().get(), false, true);
+                ItemStack spawnStack = this.getStackWithTags(itemStack, false, this.getMoaType(), false, true);
                 Entity entity = AetherEntityTypes.MOA.get().spawn(serverLevel, spawnStack, player, blockPos1, MobSpawnType.SPAWN_EGG, true, !Objects.equals(blockPos, blockPos1) && direction == Direction.UP);
                 if (entity instanceof Moa) {
                     level.gameEvent(player, GameEvent.ENTITY_PLACE, blockPos);
@@ -116,7 +123,7 @@ public class MoaEggItem extends Item
                 if (!(level.getBlockState(blockpos).getBlock() instanceof LiquidBlock)) {
                     return InteractionResultHolder.pass(itemstack);
                 } else if (level.mayInteract(player, blockpos) && player.mayUseItemAt(blockpos, hitResult.getDirection(), itemstack)) {
-                    ItemStack spawnStack = this.getStackWithTags(itemstack, false, this.getMoaType().get(), false, true);
+                    ItemStack spawnStack = this.getStackWithTags(itemstack, false, this.getMoaType(), false, true);
                     Entity entity = AetherEntityTypes.MOA.get().spawn(serverLevel, spawnStack, player, blockpos, MobSpawnType.SPAWN_EGG, false, false);
                     if (entity == null) {
                         return InteractionResultHolder.pass(itemstack);
@@ -149,13 +156,17 @@ public class MoaEggItem extends Item
         return this.color;
     }
 
-    public Supplier<MoaType> getMoaType() {
-        return this.moaType;
+    public MoaType getMoaType() {
+        return this.moaType.get();
+    }
+
+    public ResourceLocation getMoaTypeId() {
+        return this.moaTypeId;
     }
 
     @Nullable
     public static MoaEggItem byId(MoaType moaType) {
-        for (Map.Entry<RegistryObject<MoaType>, MoaEggItem> holder : BY_ID.entrySet()) {
+        for (Map.Entry<Supplier<? extends MoaType>, MoaEggItem> holder : BY_ID.entrySet()) {
             if (moaType.getId().equals(holder.getKey().get().getId())) {
                 return holder.getValue();
             }


### PR DESCRIPTION
Fixes #806.

Uses type of `Supplier<? extends MoaType>` rather than `RegistryObject<MoaType>` for keeping track of moas. This has two benefits:

1. Other mods can use their own suppliers to make their own moa type eggs.
2. Suppliers or RegistryObjects can be of a subtype of MoaType without needing to resort to unnecessary casting.

PR editing has been enabled in case you want to build off of what I provided.