### PR TITLE
improv(entity): Valkyrie and Valkyrie Queen improvements

### DIFF
--- a/src/main/java/com/gildedgames/aether/api/DungeonTracker.java
+++ b/src/main/java/com/gildedgames/aether/api/DungeonTracker.java
@@ -42,7 +42,7 @@ public record DungeonTracker<T extends Mob & BossMob<T>>(T boss, Vec3 originCoor
                     if (x == Math.floor(this.roomBounds().minX) || x == Math.ceil(this.roomBounds().maxX)
                             || y == Math.floor(this.roomBounds().minY) || y == Math.ceil(this.roomBounds().maxY)
                             || z == Math.floor(this.roomBounds().minZ) || z == Math.ceil(this.roomBounds().maxZ)) {
-                        this.boss().getLevel().setBlockAndUpdate(new BlockPos(x, y, z), AetherBlocks.LOCKED_SENTRY_STONE.get().defaultBlockState());
+                        this.boss().getLevel().setBlockAndUpdate(new BlockPos(x, y, z), AetherBlocks.LOCKED_LIGHT_ANGELIC_STONE.get().defaultBlockState());
                     }
                 }
             }

--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
@@ -129,6 +129,11 @@ public abstract class AbstractValkyrie extends Monster implements NotGrounded {
         return false;
     }
 
+    @Override
+    protected boolean canRide(@Nonnull Entity vehicle) {
+        return false;
+    }
+
     /**
      * The valkyrie will be provoked to attack the player if attacked.
      */

--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
@@ -10,7 +10,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -172,7 +171,6 @@ public abstract class AbstractValkyrie extends Monster implements NotGrounded {
 
         BlockState blockstate = this.level.getBlockState(blockpos$mutableblockpos);
         boolean flag = blockstate.is(AetherTags.Blocks.VALKYRIE_TELEPORTABLE_ON);*/
-        //TODO: Lock teleporting to tagged blocks.
         ValkyrieTeleportEvent event = AetherEventDispatch.onValkyrieTeleport(this, pX, pY, pZ);
         if (event.isCanceled()) return false;
         boolean flag = this.randomTeleport(event.getTargetX(), event.getTargetY(), event.getTargetZ(), false);
@@ -256,12 +254,12 @@ public abstract class AbstractValkyrie extends Monster implements NotGrounded {
 
         @Override
         public boolean canContinueToUse() {
-            return !this.valkyrie.onGround && this.counter <= 5;
+            return !this.valkyrie.onGround && this.counter >= 0;
         }
 
         @Override
         public void tick() {
-            if (this.counter++ >= 5 && this.valkyrie.getTarget() != null) {
+            if (this.counter-- <= 0 && this.valkyrie.getTarget() != null) {
                 Vec3 distance = this.valkyrie.getTarget().position().subtract(this.valkyrie.position());
                 double angle = Math.atan2(distance.x, distance.z);
                 this.valkyrie.setDeltaMovement(Math.sin(angle) * 0.25, this.valkyrie.getDeltaMovement().y, Math.cos(angle) * 0.25);
@@ -270,7 +268,7 @@ public abstract class AbstractValkyrie extends Monster implements NotGrounded {
 
         @Override
         public void stop() {
-            this.counter = 0;
+            this.counter = 7;
         }
 
         @Override

--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/Valkyrie.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/Valkyrie.java
@@ -41,7 +41,6 @@ public class Valkyrie extends AbstractValkyrie implements NeutralMob {
 
     public Valkyrie(EntityType<? extends Valkyrie> type, Level worldIn) {
         super(type, worldIn);
-        this.teleportTimer = this.getRandom().nextInt(200);
     }
 
     @Override

--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/boss/ValkyrieQueen.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/boss/ValkyrieQueen.java
@@ -1,6 +1,5 @@
 package com.gildedgames.aether.entity.monster.dungeon.boss;
 
-import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.api.DungeonTracker;
 import com.gildedgames.aether.block.AetherBlocks;
 import com.gildedgames.aether.client.gui.screen.ValkyrieQueenDialogueScreen;

--- a/src/main/java/com/gildedgames/aether/entity/projectile/crystal/ThunderCrystal.java
+++ b/src/main/java/com/gildedgames/aether/entity/projectile/crystal/ThunderCrystal.java
@@ -1,7 +1,6 @@
 package com.gildedgames.aether.entity.projectile.crystal;
 
 import com.gildedgames.aether.client.AetherSoundEvents;
-import com.gildedgames.aether.capability.lightning.LightningTracker;
 import com.gildedgames.aether.client.particle.AetherParticleTypes;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
@@ -13,11 +12,9 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.IndirectEntityDamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.network.NetworkHooks;
 
@@ -96,7 +93,7 @@ public class ThunderCrystal extends AbstractCrystal {
         this.hasImpulse = true;
         Vec3 vec3 = this.getDeltaMovement();
         Vec3 vec31 = target.normalize().scale(strength);
-        this.setDeltaMovement(vec3.x / 2.0D - vec31.x, vec3.y / 2 - vec31.y, vec3.z / 2.0D - vec31.z);
+        this.setDeltaMovement(vec3.x / 2.0D + vec31.x, vec3.y / 2 + vec31.y, vec3.z / 2.0D + vec31.z);
     }
 
     /**


### PR DESCRIPTION
```
Valkyries now have their lunge attack back.
Valkyries no longer get stuck in boats.
Valkyrie queens will teleport up to the player if the player is too high for them to reach for too long.

Partially addressed #776 
```

