### PR TITLE
fix(entity): Rework valkyrie lunge and increase slider dungeon bounds

### DIFF
--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/AbstractValkyrie.java
@@ -270,7 +270,7 @@ public abstract class AbstractValkyrie extends Monster implements NotGrounded {
             if (this.counter-- <= 0 && this.valkyrie.getTarget() != null) {
                 Vec3 distance = this.valkyrie.getTarget().position().subtract(this.valkyrie.position());
                 double angle = Math.atan2(distance.x, distance.z);
-                this.valkyrie.setDeltaMovement(Math.sin(angle) * 0.25, this.valkyrie.getDeltaMovement().y, Math.cos(angle) * 0.25);
+                this.valkyrie.setDeltaMovement(this.valkyrie.getDeltaMovement().add(Math.sin(angle) * 0.35, 0, Math.cos(angle) * 0.35));
             }
         }
 

--- a/src/main/java/com/gildedgames/aether/world/structurepiece/BronzeDungeonPieces.java
+++ b/src/main/java/com/gildedgames/aether/world/structurepiece/BronzeDungeonPieces.java
@@ -77,7 +77,7 @@ public class BronzeDungeonPieces {
                 slider.setPos(xPos, pos.getY(), zPos);
                 slider.setDungeon(new DungeonTracker<>(slider,
                         slider.position(),
-                        new AABB(this.boundingBox.minX(), this.boundingBox.minY(), this.boundingBox.minZ(), this.boundingBox.maxX(), this.boundingBox.maxY(), this.boundingBox.maxZ()),
+                        new AABB(this.boundingBox.minX(), this.boundingBox.minY(), this.boundingBox.minZ(), this.boundingBox.maxX() + 1, this.boundingBox.maxY() + 1, this.boundingBox.maxZ() + 1),
                         new ArrayList<>()));
                 slider.finalizeSpawn(level, level.getCurrentDifficultyAt(pos), MobSpawnType.STRUCTURE, null, null);
                 level.getLevel().addFreshEntity(slider);


### PR DESCRIPTION
```
Valkyries now take knockback into account instead of juggernauting through.
Bronze dungeons properly set the slider's dungeon bounds now.
```