### PR TITLE
improv(block): Fix locked overlay applying to dungeon doorways

### DIFF
--- a/src/generated/resources/.cache/7452c67c310ec945bc69debcbc8a0b3dc4f92884
+++ b/src/generated/resources/.cache/7452c67c310ec945bc69debcbc8a0b3dc4f92884
@@ -1,4 +1,4 @@
-// 1.19.2	2022-11-05T14:02:46.9994638	Aether Block Tags
+// 1.19.2	2022-11-26T17:48:29.0998739	Aether Block Tags
 fc9b66cee900f1b4f341fcec6da19eb45d575f43 data/aether/tags/blocks/aechor_plant_spawnable_on.json
 f2dedadb4e94e780ebd949b551d3349f0210feb9 data/aether/tags/blocks/aerclouds.json
 16a15f0767946dfa61ee9dfb544a3aeb3439340c data/aether/tags/blocks/aerogel.json
@@ -18,10 +18,11 @@ b7b37d30e23e65ee6925f4068e6d142f874fadd6 data/aether/tags/blocks/dungeon_blocks.
 14656c5bacbe085775af17b37cc6fe661f3c5c00 data/aether/tags/blocks/hellfire_blocks.json
 7a6ab5f621a7a401034f482edac807cc203ff72b data/aether/tags/blocks/holystone.json
 b39b9a730fa6d6ce0d57bcbb88a249b6617d6822 data/aether/tags/blocks/infiniburn.json
-fa94db494e54603d2b82615f7071ecad7080ce64 data/aether/tags/blocks/locked_dungeon_blocks.json
+022a06d2a296e488a68e47fe0cebd62c586c55ea data/aether/tags/blocks/locked_dungeon_blocks.json
 72fbe793b5c4be3b794fd87fd89b3a6293d2241c data/aether/tags/blocks/quicksoil_can_generate.json
 adc60af0231716fa635707337a7147da3eef4eb6 data/aether/tags/blocks/sentry_blocks.json
 df16ed8f5964fbb722ae2040903fb88c95ad2b99 data/aether/tags/blocks/skyroot_logs.json
+a8998a288a879cb5ffe96f3d45cbd69d9d50d863 data/aether/tags/blocks/slider_unbreakable.json
 fc9b66cee900f1b4f341fcec6da19eb45d575f43 data/aether/tags/blocks/swet_spawnable_on.json
 35939e5beaa968e84aa88a102d8a79663d47ab1d data/aether/tags/blocks/trapped_dungeon_blocks.json
 c26f64255e81ace6a67fcf973a34043471ebff1d data/aether/tags/blocks/treasure_doorway_dungeon_blocks.json

--- a/src/generated/resources/.cache/797771fa92c9781c2c346f8c74e71a22b0dcdf25
+++ b/src/generated/resources/.cache/797771fa92c9781c2c346f8c74e71a22b0dcdf25
@@ -1,4 +1,4 @@
-// 1.19.2	2022-11-21T22:45:00.9922521	Aether Item Tags
+// 1.19.2	2022-11-26T17:48:28.9358745	Aether Item Tags
 688ae9828b941d1f6760e1e9d3126fac6b99608c data/aether/tags/items/accepted_music_discs.json
 b1b83b96d9600b7878597cc26851b843bf99a3dd data/aether/tags/items/accessories.json
 6404c17e75ed612591fd253fd1cfd8c6a5ea4a8a data/aether/tags/items/aerbunny_temptation_items.json
@@ -30,7 +30,7 @@ bbd431b5ea0dbbac9aa71e30c71140e28ae93250 data/aether/tags/items/freezable_rings.
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/holy_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/ice_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/lightning_repairing.json
-fa94db494e54603d2b82615f7071ecad7080ce64 data/aether/tags/items/locked_dungeon_blocks.json
+022a06d2a296e488a68e47fe0cebd62c586c55ea data/aether/tags/items/locked_dungeon_blocks.json
 27515cc6012baf242e2835b3aaee05b65357b60a data/aether/tags/items/moa_eggs.json
 c674b7a242891866e5ebc42cb684a2d8113fd673 data/aether/tags/items/moa_food_items.json
 d0f09b8dfc6381aa826e9b27dfc398b8b7c02625 data/aether/tags/items/moa_temptation_items.json

--- a/src/generated/resources/data/aether/tags/blocks/locked_dungeon_blocks.json
+++ b/src/generated/resources/data/aether/tags/blocks/locked_dungeon_blocks.json
@@ -5,8 +5,6 @@
     "aether:locked_angelic_stone",
     "aether:locked_light_angelic_stone",
     "aether:locked_hellfire_stone",
-    "aether:locked_light_hellfire_stone",
-    "#aether:boss_doorway_dungeon_blocks",
-    "#aether:treasure_doorway_dungeon_blocks"
+    "aether:locked_light_hellfire_stone"
   ]
 }

--- a/src/generated/resources/data/aether/tags/blocks/slider_unbreakable.json
+++ b/src/generated/resources/data/aether/tags/blocks/slider_unbreakable.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "#aether:locked_dungeon_blocks",
+    "#aether:trapped_dungeon_blocks",
+    "#aether:boss_doorway_dungeon_blocks",
+    "#aether:treasure_doorway_dungeon_blocks"
+  ]
+}

--- a/src/generated/resources/data/aether/tags/items/locked_dungeon_blocks.json
+++ b/src/generated/resources/data/aether/tags/items/locked_dungeon_blocks.json
@@ -5,8 +5,6 @@
     "aether:locked_angelic_stone",
     "aether:locked_light_angelic_stone",
     "aether:locked_hellfire_stone",
-    "aether:locked_light_hellfire_stone",
-    "#aether:boss_doorway_dungeon_blocks",
-    "#aether:treasure_doorway_dungeon_blocks"
+    "aether:locked_light_hellfire_stone"
   ]
 }

--- a/src/main/java/com/gildedgames/aether/AetherTags.java
+++ b/src/main/java/com/gildedgames/aether/AetherTags.java
@@ -31,6 +31,7 @@ public class AetherTags {
 		public static final TagKey<Block> SENTRY_BLOCKS = tag("sentry_blocks");
 		public static final TagKey<Block> ANGELIC_BLOCKS = tag("angelic_blocks");
 		public static final TagKey<Block> HELLFIRE_BLOCKS = tag("hellfire_blocks");
+		public static final TagKey<Block> SLIDER_UNBREAKABLE = tag("slider_unbreakable");
 		public static final TagKey<Block> GRAVITITE_ABILITY_BLACKLIST = tag("gravitite_ability_blacklist");
 		public static final TagKey<Block> AETHER_ANIMALS_SPAWNABLE_ON = tag("aether_animals_spawnable_on");
 		public static final TagKey<Block> AERWHALE_SPAWNABLE_ON = tag("aerwhale_spawnable_on");

--- a/src/main/java/com/gildedgames/aether/data/generators/tags/AetherBlockTagData.java
+++ b/src/main/java/com/gildedgames/aether/data/generators/tags/AetherBlockTagData.java
@@ -79,11 +79,7 @@ public class AetherBlockTagData extends BlockTagsProvider
                 AetherBlocks.LOCKED_ANGELIC_STONE.get(),
                 AetherBlocks.LOCKED_LIGHT_ANGELIC_STONE.get(),
                 AetherBlocks.LOCKED_HELLFIRE_STONE.get(),
-                AetherBlocks.LOCKED_LIGHT_HELLFIRE_STONE.get())
-                .addTags(
-                        AetherTags.Blocks.BOSS_DOORWAY_DUNGEON_BLOCKS,
-                        AetherTags.Blocks.TREASURE_DOORWAY_DUNGEON_BLOCKS
-                );
+                AetherBlocks.LOCKED_LIGHT_HELLFIRE_STONE.get());
         tag(AetherTags.Blocks.TRAPPED_DUNGEON_BLOCKS).add(
                 AetherBlocks.TRAPPED_CARVED_STONE.get(),
                 AetherBlocks.TRAPPED_SENTRY_STONE.get(),
@@ -141,6 +137,11 @@ public class AetherBlockTagData extends BlockTagsProvider
                 AetherBlocks.HELLFIRE_STAIRS.get(),
                 AetherBlocks.HELLFIRE_SLAB.get(),
                 AetherBlocks.HELLFIRE_WALL.get());
+        tag(AetherTags.Blocks.SLIDER_UNBREAKABLE).addTags(
+                AetherTags.Blocks.LOCKED_DUNGEON_BLOCKS,
+                AetherTags.Blocks.TRAPPED_DUNGEON_BLOCKS,
+                AetherTags.Blocks.BOSS_DOORWAY_DUNGEON_BLOCKS,
+                AetherTags.Blocks.TREASURE_DOORWAY_DUNGEON_BLOCKS);
         tag(AetherTags.Blocks.GRAVITITE_ABILITY_BLACKLIST).addTags(
                 BlockTags.BUTTONS,
                 BlockTags.PRESSURE_PLATES,
@@ -154,20 +155,17 @@ public class AetherBlockTagData extends BlockTagsProvider
         tag(AetherTags.Blocks.COCKATRICE_SPAWNABLE_BLACKLIST).addTags(
                 AetherTags.Blocks.DUNGEON_BLOCKS,
                 AetherTags.Blocks.LOCKED_DUNGEON_BLOCKS,
-                AetherTags.Blocks.TRAPPED_DUNGEON_BLOCKS
-        );
+                AetherTags.Blocks.TRAPPED_DUNGEON_BLOCKS);
         tag(AetherTags.Blocks.INFINIBURN).addTag(BlockTags.INFINIBURN_OVERWORLD);
         tag(AetherTags.Blocks.ALLOWED_FLAMMABLES).add(Blocks.SOUL_SAND, Blocks.SOUL_SOIL).addTags(
                 AetherTags.Blocks.INFINIBURN,
                 AetherTags.Blocks.HELLFIRE_BLOCKS);
         tag(AetherTags.Blocks.QUICKSOIL_CAN_GENERATE).add(
                 AetherBlocks.AETHER_DIRT.get(),
-                AetherBlocks.HOLYSTONE.get()
-        );
+                AetherBlocks.HOLYSTONE.get());
         tag(AetherTags.Blocks.VALKYRIE_TELEPORTABLE_ON).add(
                 AetherBlocks.ANGELIC_STONE.get(),
-                AetherBlocks.LIGHT_ANGELIC_STONE.get()
-        );
+                AetherBlocks.LIGHT_ANGELIC_STONE.get());
         tag(AetherTags.Blocks.TREATED_AS_AETHER_BLOCK);
 
         //vanilla

--- a/src/main/java/com/gildedgames/aether/entity/monster/dungeon/boss/Slider.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/dungeon/boss/Slider.java
@@ -830,7 +830,7 @@ public class Slider extends PathfinderMob implements BossMob<Slider>, Enemy {
             if (this.slider.getDeltaMovement().equals(Vec3.ZERO) || isInside) {
                 for (BlockPos pos : BlockPos.betweenClosed(min, max)) {
                     BlockState blockState = this.slider.level.getBlockState(pos);
-                    if (!blockState.isAir() && !blockState.is(AetherTags.Blocks.LOCKED_DUNGEON_BLOCKS)) {
+                    if (!blockState.isAir() && !blockState.is(AetherTags.Blocks.SLIDER_UNBREAKABLE)) {
                         if (ForgeEventFactory.getMobGriefingEvent(this.slider.level, this.slider) && this.slider.getDungeon() != null && this.slider.getDungeon().roomBounds().contains(Vec3.atCenterOf(pos))) {
                             this.slider.level.destroyBlock(pos, true, this.slider);
                             this.blockDestroySmoke(pos);


### PR DESCRIPTION
The locked_dungeon_blocks tag is now only used for locked blocks, and the Slider now has its own separate tag for "locked" blocks it can't break which is slider_unbreakable