### PR TITLE
fix(structure): Fix bronze dungeons preventing trees from generating

### DIFF
--- a/src/main/java/com/gildedgames/aether/world/structure/BronzeDungeonStructure.java
+++ b/src/main/java/com/gildedgames/aether/world/structure/BronzeDungeonStructure.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureType;
 import net.minecraft.world.level.levelgen.structure.pieces.StructurePiecesBuilder;
@@ -43,6 +44,14 @@ public class BronzeDungeonStructure extends Structure {
         BronzeDungeonGraph graph = new BronzeDungeonGraph(builder, context, this.maxRooms);
         graph.initializeDungeon(startPos);
         graph.populatePiecesBuilder();
+    }
+
+    /**
+     * Override to prevent beardifier bounding box adjustment
+     */
+    @Override
+    public BoundingBox adjustBoundingBox(BoundingBox box) {
+        return box;
     }
 
     @Override


### PR DESCRIPTION
This PR prevents the `StructureStart` from inflating the bronze dungeon's bounding box.