### PR TITLE
fix(item): Accessories no longer have "curio" tag

### DIFF
--- a/src/generated/resources/.cache/232d7dc54f63e89526c247ba29265b5afad0215c
+++ b/src/generated/resources/.cache/232d7dc54f63e89526c247ba29265b5afad0215c
@@ -1,4 +1,4 @@
-// 1.19.3	2022-12-19T11:26:00.1320023	Tags for minecraft:item mod id aether
+// 1.19.3	2022-12-24T09:35:46.383109626	Tags for minecraft:item mod id aether
 688ae9828b941d1f6760e1e9d3126fac6b99608c data/aether/tags/items/accepted_music_discs.json
 b1b83b96d9600b7878597cc26851b843bf99a3dd data/aether/tags/items/accessories.json
 6404c17e75ed612591fd253fd1cfd8c6a5ea4a8a data/aether/tags/items/aerbunny_temptation_items.json
@@ -11,8 +11,8 @@ eb4cdf6f9a5abc219ab893139c2ed512fb1e06de data/aether/tags/items/angelic_blocks.j
 d9dcb253fe96193998f03751892165ee5f5c1924 data/aether/tags/items/boss_doorway_dungeon_blocks.json
 ac1d9421f0295d2b3a733f9b307cb39c2a63629d data/aether/tags/items/candy_cane_repairing.json
 c365c56c9363907f546b5d4778b8608912fa27c9 data/aether/tags/items/crafts_skyroot_planks.json
-321cad0c802b794f364a9ba5a34536ecc36271ec data/aether/tags/items/darts.json
 689feb68cd191d91398feec72aac2a3ba6fc6c1e data/aether/tags/items/dart_shooters.json
+321cad0c802b794f364a9ba5a34536ecc36271ec data/aether/tags/items/darts.json
 e76fa7895d12cebf68ad53507c85f84321c922ad data/aether/tags/items/deployable_parachutes.json
 b7b37d30e23e65ee6925f4068e6d142f874fadd6 data/aether/tags/items/dungeon_blocks.json
 1afb0e16f412f35b65a41d9abe8ae898f087e419 data/aether/tags/items/dungeon_keys.json
@@ -26,9 +26,9 @@ bbd431b5ea0dbbac9aa71e30c71140e28ae93250 data/aether/tags/items/freezable_rings.
 24739a7c6e39fa7efc02d98276194ef47fa70290 data/aether/tags/items/gravitite_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/hammer_of_notch_repairing.json
 14656c5bacbe085775af17b37cc6fe661f3c5c00 data/aether/tags/items/hellfire_blocks.json
+35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/holy_repairing.json
 7a6ab5f621a7a401034f482edac807cc203ff72b data/aether/tags/items/holystone.json
 336a5cf28e3a807615f25965e0a90c7bf33dd3ac data/aether/tags/items/holystone_repairing.json
-35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/holy_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/ice_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/lightning_repairing.json
 022a06d2a296e488a68e47fe0cebd62c586c55ea data/aether/tags/items/locked_dungeon_blocks.json
@@ -59,7 +59,7 @@ c26f64255e81ace6a67fcf973a34043471ebff1d data/aether/tags/items/treasure_doorway
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/valkyrie_repairing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/aether/tags/items/vampire_repairing.json
 794ba2e4990dd4fa1823ea008d8b78437527dacd data/aether/tags/items/zanite_repairing.json
-9a6a0559b86f300f0732ed1fa52dfedf3ee222ba data/curios/tags/items/aether_accessory.json
+a1a2d0a4fe7739119da041f63194184876be952e data/curios/tags/items/aether_accessory.json
 cf5274595bae04ea85f85d2a94202d4589da1113 data/curios/tags/items/aether_cape.json
 a555483b58adf47150fdc42864f0fb7949171449 data/curios/tags/items/aether_gloves.json
 5ba247034a4019a795773918d18542d96b4123ed data/curios/tags/items/aether_pendant.json
@@ -67,7 +67,6 @@ a555483b58adf47150fdc42864f0fb7949171449 data/curios/tags/items/aether_gloves.js
 3f9727bd2367c552a68056fe20cf61a448d0e81e data/curios/tags/items/aether_shield.json
 8e6cc2addf3c57e62ffa8ec438d55516c381ff3f data/curios/tags/items/back.json
 0e01b98649475857f7dde40f8badcb78c55892af data/curios/tags/items/charm.json
-0e01b98649475857f7dde40f8badcb78c55892af data/curios/tags/items/curio.json
 0fa32a72588ce97499b47ae08f820295942e33a2 data/curios/tags/items/hands.json
 08bc785ec15e245aae0aa6cd40ad477f01bd9a4e data/curios/tags/items/necklace.json
 ebdd2c8bd23103855949f36a05e9736b88e68751 data/curios/tags/items/ring.json
@@ -77,15 +76,15 @@ ae55992a015bc68477c240af9e2959c48fba8803 data/forge/tags/items/armors/chestplate
 c6a2f3012677318fa59bcac00346119501124dc5 data/forge/tags/items/armors/leggings.json
 01f606af3f58ae6c9742c9c6e927e787256e6274 data/forge/tags/items/bookshelves.json
 27515cc6012baf242e2835b3aaee05b65357b60a data/forge/tags/items/eggs.json
-bc9de2bdb11aba0025a16f480e48e231376296ee data/forge/tags/items/fences.json
-bc9de2bdb11aba0025a16f480e48e231376296ee data/forge/tags/items/fences/wooden.json
 0bba5a874905f77d759a35126765746aff21acf2 data/forge/tags/items/fence_gates.json
 0bba5a874905f77d759a35126765746aff21acf2 data/forge/tags/items/fence_gates/wooden.json
+bc9de2bdb11aba0025a16f480e48e231376296ee data/forge/tags/items/fences.json
+bc9de2bdb11aba0025a16f480e48e231376296ee data/forge/tags/items/fences/wooden.json
 794ba2e4990dd4fa1823ea008d8b78437527dacd data/forge/tags/items/gems.json
 3549a6c0791821524c9419a608b6af0de62b3530 data/forge/tags/items/glass/colorless.json
 3e52c5c101f4f3e27d0a4c0ceb478864450a6a40 data/forge/tags/items/glass_panes/colorless.json
-47071da7c265ffd70c41ff2b88a06b237cd784f9 data/forge/tags/items/ores.json
 47071da7c265ffd70c41ff2b88a06b237cd784f9 data/forge/tags/items/ore_rates/singular.json
+47071da7c265ffd70c41ff2b88a06b237cd784f9 data/forge/tags/items/ores.json
 4d0fcd44af39fa4f1950e841827bfde973be863f data/forge/tags/items/rods/wooden.json
 01be455b4f57023ac9af8857eb885afcfb917025 data/forge/tags/items/storage_blocks.json
 addb62cbd712e3f83c6bbadcbfdf309dc0ee3cc3 data/forge/tags/items/tools.json

--- a/src/generated/resources/data/curios/tags/items/aether_accessory.json
+++ b/src/generated/resources/data/curios/tags/items/aether_accessory.json
@@ -4,10 +4,6 @@
     "aether:regeneration_stone",
     "aether:iron_bubble",
     {
-      "id": "#curios:curio",
-      "required": false
-    },
-    {
       "id": "#curios:charm",
       "required": false
     }

--- a/src/generated/resources/data/curios/tags/items/curio.json
+++ b/src/generated/resources/data/curios/tags/items/curio.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "#curios:aether_accessory"
-  ]
-}

--- a/src/main/java/com/gildedgames/aether/data/generators/tags/AetherItemTagData.java
+++ b/src/main/java/com/gildedgames/aether/data/generators/tags/AetherItemTagData.java
@@ -185,14 +185,12 @@ public class AetherItemTagData extends ItemTagsProvider {
                 AetherItems.GOLDEN_FEATHER.get(),
                 AetherItems.REGENERATION_STONE.get(),
                 AetherItems.IRON_BUBBLE.get())
-                .addOptionalTag(new ResourceLocation(Curios.MODID, "curio"))
                 .addOptionalTag(new ResourceLocation(Curios.MODID, "charm"));
         this.tag(AetherTags.Items.AETHER_SHIELD).add(AetherItems.SHIELD_OF_REPULSION.get());
         this.tag(AetherTags.Items.RING).addTag(AetherTags.Items.AETHER_RING);
         this.tag(AetherTags.Items.NECKLACE).addTag(AetherTags.Items.AETHER_PENDANT);
         this.tag(AetherTags.Items.HANDS).addTag(AetherTags.Items.AETHER_GLOVES);
         this.tag(AetherTags.Items.BACK).addTag(AetherTags.Items.AETHER_CAPE);
-        this.tag(AetherTags.Items.CURIO).addTag(AetherTags.Items.AETHER_ACCESSORY);
         this.tag(AetherTags.Items.CHARM).addTag(AetherTags.Items.AETHER_ACCESSORY);
 
         this.tag(AetherTags.Items.ACCESSORIES).addTags(


### PR DESCRIPTION
This stops the generic accessories from being able to be put in every accessory slot