### PR TITLE
refactor: Address lack of wildcards for public API

### DIFF
--- a/src/main/java/com/gildedgames/aether/api/registers/MoaType.java
+++ b/src/main/java/com/gildedgames/aether/api/registers/MoaType.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 
 public class MoaType
 {
-    private final Supplier<Item> egg;
+    private final Supplier<? extends Item> egg;
     private final int maxJumps;
     private final float speed;
     private final ResourceLocation texture;
@@ -20,7 +20,7 @@ public class MoaType
         this(properties.egg, properties.maxJumps, properties.speed, properties.texture, properties.saddleTexture);
     }
 
-    public MoaType(Supplier<Item> egg, int maxJumps, float speed, ResourceLocation texture, ResourceLocation saddleTexture) {
+    public MoaType(Supplier<? extends Item> egg, int maxJumps, float speed, ResourceLocation texture, ResourceLocation saddleTexture) {
         this.egg = egg;
         this.maxJumps = maxJumps;
         this.speed = speed;
@@ -58,13 +58,13 @@ public class MoaType
 
     public static class Properties
     {
-        private Supplier<Item> egg = AetherItems.BLUE_MOA_EGG;
+        private Supplier<? extends Item> egg = AetherItems.BLUE_MOA_EGG;
         private int maxJumps = 3;
         private float speed = 0.1F;
         private ResourceLocation texture = new ResourceLocation(Aether.MODID, "textures/entity/mobs/moa/blue_moa.png");
         private ResourceLocation saddleTexture = new ResourceLocation(Aether.MODID, "textures/entity/mobs/moa/moa_saddle.png");
 
-        public MoaType.Properties egg(Supplier<Item> egg) {
+        public MoaType.Properties egg(Supplier<? extends Item> egg) {
             this.egg = egg;
             return this;
         }

--- a/src/main/java/com/gildedgames/aether/block/dispenser/DispenseDartBehavior.java
+++ b/src/main/java/com/gildedgames/aether/block/dispenser/DispenseDartBehavior.java
@@ -16,9 +16,9 @@ import net.minecraft.world.level.Level;
 import java.util.function.Supplier;
 
 public class DispenseDartBehavior extends AbstractProjectileDispenseBehavior {
-    protected final Supplier<Item> dartItem;
+    protected final Supplier<? extends Item> dartItem;
 
-    public DispenseDartBehavior(Supplier<Item> dartItem) {
+    public DispenseDartBehavior(Supplier<? extends Item> dartItem) {
         this.dartItem = dartItem;
     }
 

--- a/src/main/java/com/gildedgames/aether/block/natural/LeavesWithParticlesBlock.java
+++ b/src/main/java/com/gildedgames/aether/block/natural/LeavesWithParticlesBlock.java
@@ -1,6 +1,7 @@
 package com.gildedgames.aether.block.natural;
 
 import com.gildedgames.aether.block.AetherBlockStateProperties;
+import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -13,9 +14,9 @@ import net.minecraft.world.level.Level;
 import java.util.function.Supplier;
 
 public class LeavesWithParticlesBlock extends LeavesBlock {
-	private final Supplier<SimpleParticleType> particle;
+	private final Supplier<? extends ParticleOptions> particle;
 
-	public LeavesWithParticlesBlock(Supplier<SimpleParticleType> particle, Properties properties) {
+	public LeavesWithParticlesBlock(Supplier<? extends ParticleOptions> particle, Properties properties) {
 		super(properties);
 		this.registerDefaultState(this.defaultBlockState().setValue(AetherBlockStateProperties.DOUBLE_DROPS, false));
 		this.particle = particle;

--- a/src/main/java/com/gildedgames/aether/client/renderer/entity/ParachuteRenderer.java
+++ b/src/main/java/com/gildedgames/aether/client/renderer/entity/ParachuteRenderer.java
@@ -21,9 +21,9 @@ import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
 public class ParachuteRenderer extends EntityRenderer<Parachute> {
-    private final Supplier<Block> parachuteBlock;
+    private final Supplier<? extends Block> parachuteBlock;
 
-    public ParachuteRenderer(EntityRendererProvider.Context context, Supplier<Block> parachuteBlock) {
+    public ParachuteRenderer(EntityRendererProvider.Context context, Supplier<? extends Block> parachuteBlock) {
         super(context);
         this.parachuteBlock = parachuteBlock;
         this.shadowRadius = 0.0F;

--- a/src/main/java/com/gildedgames/aether/data/providers/AetherRecipeProvider.java
+++ b/src/main/java/com/gildedgames/aether/data/providers/AetherRecipeProvider.java
@@ -350,7 +350,7 @@ public abstract class AetherRecipeProvider extends RecipeProvider {
                 .unlockedBy(getHasName(result), has(result));
     }
 
-    protected static IncubationBuilder moaIncubationRecipe(EntityType<?> entity, Supplier<MoaType> moaType, ItemLike ingredient) {
+    protected static IncubationBuilder moaIncubationRecipe(EntityType<?> entity, Supplier<? extends MoaType> moaType, ItemLike ingredient) {
         CompoundTag tag = new CompoundTag();
         tag.putBoolean("IsBaby", true);
         tag.putString("MoaType", moaType.get().toString());

--- a/src/main/java/com/gildedgames/aether/item/accessories/gloves/GlovesItem.java
+++ b/src/main/java/com/gildedgames/aether/item/accessories/gloves/GlovesItem.java
@@ -23,9 +23,9 @@ public class GlovesItem extends AccessoryItem {
     protected final double damage;
     protected ResourceLocation GLOVES_TEXTURE;
     protected ResourceLocation GLOVES_SLIM_TEXTURE;
-    protected final Supplier<SoundEvent> equipSound;
+    protected final Supplier<? extends SoundEvent> equipSound;
 
-    public GlovesItem(double punchDamage, String glovesName, Supplier<SoundEvent> glovesSound, Properties properties) {
+    public GlovesItem(double punchDamage, String glovesName, Supplier<? extends SoundEvent> glovesSound, Properties properties) {
         super(properties);
         this.damage = punchDamage;
         this.setRenderTexture(Aether.MODID, glovesName);

--- a/src/main/java/com/gildedgames/aether/item/accessories/pendant/PendantItem.java
+++ b/src/main/java/com/gildedgames/aether/item/accessories/pendant/PendantItem.java
@@ -12,9 +12,9 @@ import java.util.function.Supplier;
 
 public class PendantItem extends AccessoryItem {
     protected ResourceLocation PENDANT_LOCATION;
-    protected final Supplier<SoundEvent> equipSound;
+    protected final Supplier<? extends SoundEvent> equipSound;
 
-    public PendantItem(String pendantLocation, Supplier<SoundEvent> pendantSound, Properties properties) {
+    public PendantItem(String pendantLocation, Supplier<? extends SoundEvent> pendantSound, Properties properties) {
         super(properties);
         this.setRenderTexture(Aether.MODID, pendantLocation);
         this.equipSound = pendantSound;

--- a/src/main/java/com/gildedgames/aether/item/accessories/ring/RingItem.java
+++ b/src/main/java/com/gildedgames/aether/item/accessories/ring/RingItem.java
@@ -9,9 +9,9 @@ import top.theillusivec4.curios.api.type.capability.ICurio;
 import java.util.function.Supplier;
 
 public class RingItem extends AccessoryItem {
-    protected final Supplier<SoundEvent> equipSound;
+    protected final Supplier<? extends SoundEvent> equipSound;
 
-    public RingItem(Supplier<SoundEvent> ringSound, Properties properties) {
+    public RingItem(Supplier<? extends SoundEvent> ringSound, Properties properties) {
         super(properties);
         this.equipSound = ringSound;
     }

--- a/src/main/java/com/gildedgames/aether/item/block/EntityBlockItem.java
+++ b/src/main/java/com/gildedgames/aether/item/block/EntityBlockItem.java
@@ -11,14 +11,14 @@ import net.minecraftforge.common.util.NonNullSupplier;
 import java.util.function.Consumer;
 
 public class EntityBlockItem extends BlockItem {
-    private final LazyOptional<BlockEntity> blockEntity;
+    private final LazyOptional<? extends BlockEntity> blockEntity;
 
-    public <B extends Block> EntityBlockItem(B block, NonNullSupplier<BlockEntity> blockEntity, Properties properties) {
+    public <B extends Block> EntityBlockItem(B block, NonNullSupplier<? extends BlockEntity> blockEntity, Properties properties) {
         super(block, properties);
         this.blockEntity = LazyOptional.of(blockEntity);
     }
 
-    public LazyOptional<BlockEntity> getBlockEntity() {
+    public LazyOptional<? extends BlockEntity> getBlockEntity() {
         return this.blockEntity;
     }
 

--- a/src/main/java/com/gildedgames/aether/item/combat/DartShooterItem.java
+++ b/src/main/java/com/gildedgames/aether/item/combat/DartShooterItem.java
@@ -25,9 +25,9 @@ import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraftforge.event.ForgeEventFactory;
 
 public class DartShooterItem extends ProjectileWeaponItem implements Vanishable {
-    private final Supplier<Item> dartType;
+    private final Supplier<? extends Item> dartType;
 
-    public DartShooterItem(Supplier<Item> dartType, Properties properties) {
+    public DartShooterItem(Supplier<? extends Item> dartType, Properties properties) {
         super(properties);
         this.dartType = dartType;
     }
@@ -161,9 +161,9 @@ public class DartShooterItem extends ProjectileWeaponItem implements Vanishable 
     }
 
     /**
-     * @return A {@link Supplier Supplier&lt;Item&gt;} that gives the Dart item that this Dart Shooter is capable of using as ammo.
+     * @return A {@link Supplier Supplier&lt;? extends Item&gt;} that gives the Dart item that this Dart Shooter is capable of using as ammo.
      */
-    public Supplier<Item> getDartType() {
+    public Supplier<? extends Item> getDartType() {
         return this.dartType;
     }
 }

--- a/src/main/java/com/gildedgames/aether/item/miscellaneous/ParachuteItem.java
+++ b/src/main/java/com/gildedgames/aether/item/miscellaneous/ParachuteItem.java
@@ -17,9 +17,9 @@ public class ParachuteItem extends Item {
     /**
      * The {@link Parachute} that this item can spawn in.
      */
-    protected final Supplier<EntityType<Parachute>> parachuteEntity;
+    protected final Supplier<? extends EntityType<? extends Parachute>> parachuteEntity;
 
-    public ParachuteItem(Supplier<EntityType<Parachute>> parachuteEntity, Properties properties) {
+    public ParachuteItem(Supplier<? extends EntityType<? extends Parachute>> parachuteEntity, Properties properties) {
         super(properties);
         this.parachuteEntity = parachuteEntity;
     }
@@ -59,7 +59,7 @@ public class ParachuteItem extends Item {
         return InteractionResultHolder.pass(heldStack);
     }
 
-    public Supplier<EntityType<Parachute>> getParachuteEntity() {
+    public Supplier<? extends EntityType<? extends Parachute>> getParachuteEntity() {
         return this.parachuteEntity;
     }
 }


### PR DESCRIPTION
# You can't escape me.

Hi! Supersedes #808.

## Maintaining Public API

The Aether mod is a very popular mod and many people will want to make add-on mods (including, but not limited to, Lost Content). Therefore, it is imperative that your public API (which isn't just the `api` package, but anything that can be reasonably interfaced with by a third-party) is as smooth to work with as possible.

### The Trouble with Generics

The issue with generic types is that they are very static for what their purpose actually is. When you make a method that has a method parameter `Block`, the accepted argument should be of type `Block` but it can also be of any implementation of it. This is not the case with nested types, as they are not interpreted at runtime (generic types are erased at compile time *except for method and class type arguments*). This means that if a method parameter is `Supplier<Block>`, the required argument can be of a subtype of `Supplier` but the generic type must be declared as `Block` and not of any other subtype. This leads to issues where the third party (or even yourself) has to resort to hacky and potentially dangerous type erasure through unchecked casting to get the results necessary.

### Our unfortunate solution

The solution, of course, is to use wildcards. Obviously wildcards don't need to be used for absolutely everything (especially if a class is final), but it eliminates underlying issue I have stated earlier, making interfacing with the public API cleaner and painless. I've included as many of these wildcards as I could in this PR, while omitting the cases where wildcards would be inappropriate or unnecessary (such as private API, final classes, and return types in some cases).

## tl;dr

please use wildcards for public API thanks now merge me bitch