### PR TITLE
fix(entity): The slider ignores shields

### DIFF
--- a/src/main/java/com/gildedgames/aether/event/hooks/EntityHooks.java
+++ b/src/main/java/com/gildedgames/aether/event/hooks/EntityHooks.java
@@ -17,6 +17,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.*;
@@ -99,6 +100,10 @@ public class EntityHooks {
             return entityHitResult.getEntity() instanceof Slider && projectileEntity instanceof FishingHook;
         }
         return false;
+    }
+
+    public static boolean preventSliderShieldBlock(DamageSource source) {
+        return source.getEntity() instanceof Slider;
     }
 
     public static boolean lightningHitKeys(Entity entity) {

--- a/src/main/java/com/gildedgames/aether/event/listeners/EntityListener.java
+++ b/src/main/java/com/gildedgames/aether/event/listeners/EntityListener.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.event.listeners;
 
+import com.gildedgames.aether.entity.monster.dungeon.boss.slider.Slider;
 import com.gildedgames.aether.event.hooks.EntityHooks;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -10,6 +11,7 @@ import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
+import net.minecraftforge.event.entity.living.ShieldBlockEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -48,6 +50,13 @@ public class EntityListener {
         Entity projectileEntity = event.getEntity();
         HitResult rayTraceResult = event.getRayTraceResult();
         event.setCanceled(EntityHooks.preventSliderHooked(projectileEntity, rayTraceResult));
+    }
+
+    @SubscribeEvent
+    public static void onShieldBlock(ShieldBlockEvent event) {
+        if (!event.isCanceled()) {
+            event.setCanceled(EntityHooks.preventSliderShieldBlock(event.getDamageSource()));
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
See #311 

The slider now ignores shields to prevent eating through their durability.