### PR TITLE
fix: Items now render in hand properly with Invisibility Cloak

### DIFF
--- a/src/main/java/com/gildedgames/aether/client/event/hooks/HandRenderHooks.java
+++ b/src/main/java/com/gildedgames/aether/client/event/hooks/HandRenderHooks.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.client.event.hooks;
 
+import com.gildedgames.aether.capability.player.AetherPlayer;
 import com.gildedgames.aether.client.renderer.accessory.GlovesRenderer;
 import com.gildedgames.aether.client.renderer.accessory.ShieldOfRepulsionRenderer;
 import com.gildedgames.aether.item.accessories.gloves.GlovesItem;
@@ -22,40 +23,48 @@ import top.theillusivec4.curios.api.client.ICurioRenderer;
 public class HandRenderHooks {
     public static void renderGloveHandOverlay(ItemInHandRenderer itemInHandRenderer, AbstractClientPlayer player, InteractionHand hand, float pitch, float swingProgress, float equippedProgress, PoseStack poseStack, MultiBufferSource buffer, int combinedLight) {
         if (player != null) {
-            CuriosApi.getCuriosHelper().findFirstCurio(player, (item) -> item.getItem() instanceof GlovesItem).ifPresent((slotResult) -> {
-                String identifier = slotResult.slotContext().identifier();
-                int id = slotResult.slotContext().index();
-                ItemStack itemStack = slotResult.stack();
-                CuriosApi.getCuriosHelper().getCuriosHandler(player).ifPresent(handler -> handler.getStacksHandler(identifier).ifPresent(stacksHandler -> {
-                    if (stacksHandler.getRenders().get(id)) {
-                        CuriosRendererRegistry.getRenderer(itemStack.getItem()).ifPresent((renderer) -> {
-                            if (renderer instanceof GlovesRenderer glovesRenderer) {
-                                ItemStack heldItem = hand == InteractionHand.MAIN_HAND ? ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getMainHandItem() : ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getOffHandItem();
-                                renderArmWithItem(itemInHandRenderer, glovesRenderer, itemStack, player, heldItem, hand, pitch, swingProgress, equippedProgress, poseStack, buffer, combinedLight, HandRenderType.GLOVES);
+            AetherPlayer.get(player).ifPresent((aetherPlayer) -> {
+                if (!aetherPlayer.isWearingInvisibilityCloak()) {
+                    CuriosApi.getCuriosHelper().findFirstCurio(player, (item) -> item.getItem() instanceof GlovesItem).ifPresent((slotResult) -> {
+                        String identifier = slotResult.slotContext().identifier();
+                        int id = slotResult.slotContext().index();
+                        ItemStack itemStack = slotResult.stack();
+                        CuriosApi.getCuriosHelper().getCuriosHandler(player).ifPresent(handler -> handler.getStacksHandler(identifier).ifPresent(stacksHandler -> {
+                            if (stacksHandler.getRenders().get(id)) {
+                                CuriosRendererRegistry.getRenderer(itemStack.getItem()).ifPresent((renderer) -> {
+                                    if (renderer instanceof GlovesRenderer glovesRenderer) {
+                                        ItemStack heldItem = hand == InteractionHand.MAIN_HAND ? ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getMainHandItem() : ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getOffHandItem();
+                                        renderArmWithItem(itemInHandRenderer, glovesRenderer, itemStack, player, heldItem, hand, pitch, swingProgress, equippedProgress, poseStack, buffer, combinedLight, HandRenderType.GLOVES);
+                                    }
+                                });
                             }
-                        });
-                    }
-                }));
+                        }));
+                    });
+                }
             });
         }
     }
 
     public static void renderShieldOfRepulsionHandOverlay(ItemInHandRenderer itemInHandRenderer, AbstractClientPlayer player, InteractionHand hand, float pitch, float swingProgress, float equippedProgress, PoseStack poseStack, MultiBufferSource buffer, int combinedLight) {
         if (player != null) {
-            CuriosApi.getCuriosHelper().findFirstCurio(player, (item) -> item.getItem() instanceof ShieldOfRepulsionItem).ifPresent((slotResult) -> {
-                String identifier = slotResult.slotContext().identifier();
-                int id = slotResult.slotContext().index();
-                ItemStack itemStack = slotResult.stack();
-                CuriosApi.getCuriosHelper().getCuriosHandler(player).ifPresent(handler -> handler.getStacksHandler(identifier).ifPresent(stacksHandler -> {
-                    if (stacksHandler.getRenders().get(id)) {
-                        CuriosRendererRegistry.getRenderer(itemStack.getItem()).ifPresent((renderer) -> {
-                            if (renderer instanceof ShieldOfRepulsionRenderer shieldRenderer) {
-                                ItemStack heldItem = hand == InteractionHand.MAIN_HAND ? ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getMainHandItem() : ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getOffHandItem();
-                                renderArmWithItem(itemInHandRenderer, shieldRenderer, itemStack, player, heldItem, hand, pitch, swingProgress, equippedProgress, poseStack, buffer, combinedLight, HandRenderType.SHIELD_OF_REPULSION);
+            AetherPlayer.get(player).ifPresent((aetherPlayer) -> {
+                if (aetherPlayer.isWearingInvisibilityCloak()) {
+                    CuriosApi.getCuriosHelper().findFirstCurio(player, (item) -> item.getItem() instanceof ShieldOfRepulsionItem).ifPresent((slotResult) -> {
+                        String identifier = slotResult.slotContext().identifier();
+                        int id = slotResult.slotContext().index();
+                        ItemStack itemStack = slotResult.stack();
+                        CuriosApi.getCuriosHelper().getCuriosHandler(player).ifPresent(handler -> handler.getStacksHandler(identifier).ifPresent(stacksHandler -> {
+                            if (stacksHandler.getRenders().get(id)) {
+                                CuriosRendererRegistry.getRenderer(itemStack.getItem()).ifPresent((renderer) -> {
+                                    if (renderer instanceof ShieldOfRepulsionRenderer shieldRenderer) {
+                                        ItemStack heldItem = hand == InteractionHand.MAIN_HAND ? ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getMainHandItem() : ((ItemInHandRendererAccessor) itemInHandRenderer).aether$getOffHandItem();
+                                        renderArmWithItem(itemInHandRenderer, shieldRenderer, itemStack, player, heldItem, hand, pitch, swingProgress, equippedProgress, poseStack, buffer, combinedLight, HandRenderType.SHIELD_OF_REPULSION);
+                                    }
+                                });
                             }
-                        });
-                    }
-                }));
+                        }));
+                    });
+                }
             });
         }
     }

--- a/src/main/java/com/gildedgames/aether/client/event/listeners/abilities/AccessoryAbilityClientListener.java
+++ b/src/main/java/com/gildedgames/aether/client/event/listeners/abilities/AccessoryAbilityClientListener.java
@@ -2,12 +2,11 @@ package com.gildedgames.aether.client.event.listeners.abilities;
 
 import com.gildedgames.aether.Aether;
 import com.gildedgames.aether.capability.player.AetherPlayer;
-import com.gildedgames.aether.util.EquipmentUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.event.RenderArmEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -33,7 +32,7 @@ public class AccessoryAbilityClientListener {
      * Disables the player's first-person arm rendering completely if wearing an Invisibility Cloak.
      */
     @SubscribeEvent
-    public static void onRenderHand(RenderHandEvent event) {
+    public static void onRenderHand(RenderArmEvent event) {
         LocalPlayer player = Minecraft.getInstance().player;
         if (!event.isCanceled() && player != null) {
             AetherPlayer.get(player).ifPresent((aetherPlayer) -> {


### PR DESCRIPTION
Held items would previously be invisible if wearing an Invisibility Cloak due to cancelling the wrong event, so the event has been switched out and some additional checks for other hand rendering has been added to make sure gloves and the repulsion shield still don't render with the invisibility cloak in first person