### PR TITLE
fix(entity): Mount-related fixes

### DIFF
--- a/src/main/java/com/gildedgames/aether/entity/monster/Swet.java
+++ b/src/main/java/com/gildedgames/aether/entity/monster/Swet.java
@@ -333,6 +333,11 @@ public class Swet extends Slime implements MountableMob {
         return AetherSoundEvents.ENTITY_SWET_SQUISH.get();
     }
 
+    @Override
+    public double getPassengersRidingOffset() {
+        return 1.4;
+    }
+
     /**
      * The player can attack the swet to try to kill it before they finish the attack.
      */

--- a/src/main/java/com/gildedgames/aether/entity/passive/Moa.java
+++ b/src/main/java/com/gildedgames/aether/entity/passive/Moa.java
@@ -182,6 +182,10 @@ public class Moa extends MountableAnimal implements WingedBird {
 			this.setHungry(false);
 			this.setAmountFed(0);
 		}
+
+		if (this.getControllingPassenger() instanceof Player) {
+			this.resetFallDistance();
+		}
 	}
 
 	@Override
@@ -196,7 +200,6 @@ public class Moa extends MountableAnimal implements WingedBird {
 					this.setFlapCooldown(15);
 				}
 			}
-			this.resetFallDistance();
 		}
 	}
 

--- a/src/main/java/com/gildedgames/aether/entity/passive/WingedAnimal.java
+++ b/src/main/java/com/gildedgames/aether/entity/passive/WingedAnimal.java
@@ -37,11 +37,6 @@ public abstract class WingedAnimal extends MountableAnimal {
                 this.setEntityOnGround(false);
             }
         }
-    }
-
-    @Override
-    public void riderTick() {
-        super.riderTick();
         if (this.getControllingPassenger() instanceof Player) {
             this.resetFallDistance();
         }


### PR DESCRIPTION
Flying mounts will no longer cause fall damage and it is now easier to see in first-person when riding Swets