### PR TITLE
refactor: Spaced out floating structures

### DIFF
--- a/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
+++ b/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
@@ -1,4 +1,4 @@
-// 1.19.3	2023-02-15T15:25:44.9778605	Registries
+// 1.19.3	2023-02-16T01:39:28.0572369	Registries
 f5deced101d2299e370ac067f29b5b355f28e634 data/aether/dimension/the_aether.json
 5655d4cd818dbc73a0baa2590d80dd274f85927d data/aether/dimension_type/the_aether.json
 9f53e09755713216c1110db9a66aa9703ec58a0a data/aether/worldgen/biome/skyroot_forest.json
@@ -61,4 +61,4 @@ aa7e50925cb356798844f47c61a11acc8f6d3ead data/aether/worldgen/structure/gold_dun
 051484619a25e72347d4afeb30e0660291ad40c9 data/aether/worldgen/structure/silver_dungeon.json
 b87a1bee531973babec39c870b7d9f367bc53944 data/aether/worldgen/structure_set/bronze_dungeon.json
 74c5f4f594d41486e3d8df1cbb87884d46154c50 data/aether/worldgen/structure_set/large_aercloud.json
-5880c9b3d1a79c0f7fac31528144359f70935864 data/aether/worldgen/structure_set/silver_and_gold_dungeons.json
+7d3446bf2d07cf5a14a1242206d65a96ed5f3853 data/aether/worldgen/structure_set/silver_and_gold_dungeons.json

--- a/src/generated/resources/data/aether/worldgen/structure_set/silver_and_gold_dungeons.json
+++ b/src/generated/resources/data/aether/worldgen/structure_set/silver_and_gold_dungeons.json
@@ -2,13 +2,13 @@
   "placement": {
     "type": "minecraft:random_spread",
     "salt": 4325806,
-    "separation": 5,
-    "spacing": 24
+    "separation": 18,
+    "spacing": 34
   },
   "structures": [
     {
       "structure": "aether:silver_dungeon",
-      "weight": 6
+      "weight": 3
     },
     {
       "structure": "aether:gold_dungeon",

--- a/src/main/java/com/gildedgames/aether/data/resources/registries/AetherStructureSets.java
+++ b/src/main/java/com/gildedgames/aether/data/resources/registries/AetherStructureSets.java
@@ -28,8 +28,8 @@ public class AetherStructureSets {
         context.register(LARGE_AERCLOUD, new StructureSet(structures.getOrThrow(AetherStructures.LARGE_AERCLOUD), new RandomSpreadStructurePlacement(6, 3, RandomSpreadType.LINEAR, 15536586)));
         context.register(BRONZE_DUNGEON, new StructureSet(structures.getOrThrow(AetherStructures.BRONZE_DUNGEON), new RandomSpreadStructurePlacement(5, 3, RandomSpreadType.LINEAR, 32146754)));
         context.register(SILVER_AND_GOLD_DUNGEONS, new StructureSet(List.of(
-        		StructureSet.entry(structures.getOrThrow(AetherStructures.SILVER_DUNGEON), 6),
+        		StructureSet.entry(structures.getOrThrow(AetherStructures.SILVER_DUNGEON), 3),
         		StructureSet.entry(structures.getOrThrow(AetherStructures.GOLD_DUNGEON), 1)),
-        	new RandomSpreadStructurePlacement(24, 5, RandomSpreadType.LINEAR, 4325806)));
+        	new RandomSpreadStructurePlacement(34, 18, RandomSpreadType.LINEAR, 4325806)));
     }
 }


### PR DESCRIPTION
Expanded separation between floating dungeons, so large structures don't spawn near each other any more. Enlarged the spacing distance too to allow for more variance in spawn locations.

![image](https://user-images.githubusercontent.com/6759864/219244156-3b9833d2-f193-4822-b84f-5d37dd50c9ed.png)
Max render distance view of another close by dungeon for a sense of scale.