### PR TITLE
fix: Gravitite-related exploits

### DIFF
--- a/src/main/java/com/gildedgames/aether/block/miscellaneous/FloatingBlock.java
+++ b/src/main/java/com/gildedgames/aether/block/miscellaneous/FloatingBlock.java
@@ -51,7 +51,7 @@ public class FloatingBlock extends Block implements Floatable {
 	@Override
 	public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
 		super.tick(state, level, pos, random);
-		if ((this.powered && level.hasNeighborSignal(pos)) || (!this.powered && isFree(level.getBlockState(pos.above())) && pos.getY() <= level.getMaxBuildHeight())) {
+		if ((this.powered && level.hasNeighborSignal(pos) && isFree(level.getBlockState(pos.above()))) || (!this.powered && isFree(level.getBlockState(pos.above())) && pos.getY() <= level.getMaxBuildHeight())) {
 			FloatingBlockEntity floatingBlockEntity = new FloatingBlockEntity(level, (double) pos.getX() + 0.5D, pos.getY(), (double) pos.getZ() + 0.5D, level.getBlockState(pos));
 			if (this.powered) {
 				floatingBlockEntity.setNatural(false);

--- a/src/main/java/com/gildedgames/aether/block/miscellaneous/FloatingBlock.java
+++ b/src/main/java/com/gildedgames/aether/block/miscellaneous/FloatingBlock.java
@@ -53,6 +53,9 @@ public class FloatingBlock extends Block implements Floatable {
 		super.tick(state, level, pos, random);
 		if ((this.powered && level.hasNeighborSignal(pos)) || (!this.powered && isFree(level.getBlockState(pos.above())) && pos.getY() <= level.getMaxBuildHeight())) {
 			FloatingBlockEntity floatingBlockEntity = new FloatingBlockEntity(level, (double) pos.getX() + 0.5D, pos.getY(), (double) pos.getZ() + 0.5D, level.getBlockState(pos));
+			if (this.powered) {
+				floatingBlockEntity.setNatural(false);
+			}
 			level.addFreshEntity(floatingBlockEntity);
 			this.floating(floatingBlockEntity);
 		} else {

--- a/src/main/java/com/gildedgames/aether/entity/block/FloatingBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/entity/block/FloatingBlockEntity.java
@@ -60,6 +60,7 @@ public class FloatingBlockEntity extends Entity {
     private int floatDistance;
     @Nullable
     public CompoundTag blockData;
+    private boolean natural = true;
 
     public FloatingBlockEntity(EntityType<? extends FloatingBlockEntity> type, Level level) {
         super(type, level);
@@ -201,8 +202,10 @@ public class FloatingBlockEntity extends Entity {
 
     private void dropBlock() {
         if (this.level instanceof ServerLevel) {
-            for (ItemStack stack : Block.getDrops(this.blockState, (ServerLevel) this.level, this.blockPosition(), null)) {
-                this.spawnAtLocation(stack);
+            if (!this.natural || !this.blockState.requiresCorrectToolForDrops()) {
+                for (ItemStack stack : Block.getDrops(this.blockState, (ServerLevel) this.level, this.blockPosition(), null)) {
+                    this.spawnAtLocation(stack);
+                }
             }
         }
     }
@@ -260,6 +263,10 @@ public class FloatingBlockEntity extends Entity {
         return this.blockState;
     }
 
+    public void setNatural(boolean natural) {
+        this.natural = natural;
+    }
+
     @Override
     public boolean isAttackable() {
         return false;
@@ -297,6 +304,7 @@ public class FloatingBlockEntity extends Entity {
         if (this.blockData != null) {
             tag.put("TileEntityData", this.blockData);
         }
+        tag.putBoolean("Natural", this.natural);
     }
 
     @Override
@@ -322,6 +330,9 @@ public class FloatingBlockEntity extends Entity {
         }
         if (this.blockState.isAir()) {
             this.blockState = Blocks.SAND.defaultBlockState();
+        }
+        if (tag.contains("Natural", 99)) {
+            this.natural = tag.getBoolean("Natural");
         }
     }
 

--- a/src/main/java/com/gildedgames/aether/entity/block/FloatingBlockEntity.java
+++ b/src/main/java/com/gildedgames/aether/entity/block/FloatingBlockEntity.java
@@ -122,7 +122,7 @@ public class FloatingBlockEntity extends Entity {
                 if ((!this.verticalCollision || this.onGround) && !canConvert) {
                     if (!this.level.isClientSide && (this.time > 100 && (blockPos1.getY() <= this.level.getMinBuildHeight() || blockPos1.getY() > this.level.getMaxBuildHeight()) || this.time > 600)) {
                         if (this.dropItem && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                            this.dropBlock();
+                            this.dropBlock(this.blockState);
                         }
                         this.discard();
                     }
@@ -134,12 +134,16 @@ public class FloatingBlockEntity extends Entity {
                             boolean canBeReplaced = blockState.canBeReplaced(new DirectionalPlaceContext(this.level, blockPos1, Direction.UP, ItemStack.EMPTY, Direction.DOWN));
                             boolean isAboveFree = FloatingBlock.isFree(this.level.getBlockState(blockPos1.above())) && (!isConcrete || !canConvert);
                             boolean canBlockSurvive = this.blockState.canSurvive(this.level, blockPos1) && !isAboveFree;
-                            if (canBeReplaced && canBlockSurvive) {
+                            if ((canBeReplaced && canBlockSurvive) || this.natural) {
                                 if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED) && this.level.getFluidState(blockPos1).is(Fluids.WATER)) {
                                     this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
                                 }
-
+                                BlockState previousBlockState = this.level.getBlockState(blockPos1);
                                 if (this.level.setBlock(blockPos1, this.blockState, 1 | 2)) {
+                                    if (this.natural && !previousBlockState.isAir()) {
+                                        this.dropBlock(previousBlockState);
+                                    }
+
                                     ((ServerLevel) this.level).getChunkSource().chunkMap.broadcast(this, new ClientboundBlockUpdatePacket(blockPos1, this.level.getBlockState(blockPos1)));
                                     this.discard();
                                     if (block instanceof Floatable floatable) {
@@ -174,13 +178,13 @@ public class FloatingBlockEntity extends Entity {
                                 } else if (this.dropItem && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
                                     this.discard();
                                     this.callOnBrokenAfterFall(block, blockPos1);
-                                    this.dropBlock();
+                                    this.dropBlock(this.blockState);
                                 }
                             } else {
                                 this.discard();
                                 if (this.dropItem && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
                                     this.callOnBrokenAfterFall(block, blockPos1);
-                                    this.dropBlock();
+                                    this.dropBlock(this.blockState);
                                 }
                             }
                         } else {
@@ -200,12 +204,10 @@ public class FloatingBlockEntity extends Entity {
         this.fallDamageMax = fallDamageMax;
     }
 
-    private void dropBlock() {
+    private void dropBlock(BlockState state) {
         if (this.level instanceof ServerLevel) {
-            if (!this.natural || !this.blockState.requiresCorrectToolForDrops()) {
-                for (ItemStack stack : Block.getDrops(this.blockState, (ServerLevel) this.level, this.blockPosition(), null)) {
-                    this.spawnAtLocation(stack);
-                }
+            for (ItemStack stack : Block.getDrops(state, (ServerLevel) this.level, this.blockPosition(), null)) {
+                this.spawnAtLocation(stack);
             }
         }
     }

--- a/src/main/java/com/gildedgames/aether/item/tools/abilities/GravititeTool.java
+++ b/src/main/java/com/gildedgames/aether/item/tools/abilities/GravititeTool.java
@@ -32,6 +32,7 @@ public interface GravititeTool {
                     if (level.getBlockEntity(pos) == null && state.getDestroySpeed(level, pos) >= 0.0F && !state.hasProperty(BlockStateProperties.DOUBLE_BLOCK_HALF) && !state.is(AetherTags.Blocks.GRAVITITE_ABILITY_BLACKLIST)) {
                         if (!level.isClientSide()) {
                             FloatingBlockEntity entity = new FloatingBlockEntity(level, pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, state);
+                            entity.setNatural(false);
                             if (state.is(BlockTags.ANVIL)) {
                                 entity.setHurtsEntities(2.0F, 40);
                             }

--- a/src/main/java/com/gildedgames/aether/item/tools/abilities/GravititeTool.java
+++ b/src/main/java/com/gildedgames/aether/item/tools/abilities/GravititeTool.java
@@ -1,5 +1,6 @@
 package com.gildedgames.aether.item.tools.abilities;
 
+import com.gildedgames.aether.block.miscellaneous.FloatingBlock;
 import com.gildedgames.aether.entity.block.FloatingBlockEntity;
 import com.gildedgames.aether.AetherTags;
 import net.minecraft.core.BlockPos;
@@ -28,7 +29,7 @@ public interface GravititeTool {
     default boolean floatBlock(Level level, BlockPos pos, ItemStack stack, BlockState state, Player player, InteractionHand hand) {
         if (stack.getItem() instanceof TieredItem tieredItem) {
             if (player != null && !player.isShiftKeyDown()) {
-                if ((stack.getDestroySpeed(state) == tieredItem.getTier().getSpeed() || stack.isCorrectToolForDrops(state)) && level.isEmptyBlock(pos.above())) {
+                if ((stack.getDestroySpeed(state) == tieredItem.getTier().getSpeed() || stack.isCorrectToolForDrops(state)) && FloatingBlock.isFree(level.getBlockState(pos.above()))) {
                     if (level.getBlockEntity(pos) == null && state.getDestroySpeed(level, pos) >= 0.0F && !state.hasProperty(BlockStateProperties.DOUBLE_BLOCK_HALF) && !state.is(AetherTags.Blocks.GRAVITITE_ABILITY_BLACKLIST)) {
                         if (!level.isClientSide()) {
                             FloatingBlockEntity entity = new FloatingBlockEntity(level, pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, state);


### PR DESCRIPTION
- Gravitite Ore can no longer be harvested by using a torch if the ore is natural; trying to break it will instead break the torch; non-natural floating blocks like powered Enchanted Gravitite and ones from Gravitite Tools will break when interacting with these kinds of blocks though. 
- Enchanted Gravitite has a better placement check to prevent a duplication bug.
