### PR TITLE
mild aerbunny debuff

### DIFF
--- a/src/main/java/com/gildedgames/aether/entity/passive/Aerbunny.java
+++ b/src/main/java/com/gildedgames/aether/entity/passive/Aerbunny.java
@@ -119,7 +119,7 @@ public class Aerbunny extends AetherAnimal {
                             if (this.lastPos == null) {
                                 this.lastPos = this.position();
                             }
-                            if (!player.isOnGround() && aetherPlayer.isJumping() && player.getDeltaMovement().y <= 0.0 && this.position().y() < this.lastPos.y() - 0.55) {
+                            if (!player.isOnGround() && aetherPlayer.isJumping() && player.getDeltaMovement().y <= 0.0 && this.position().y() < this.lastPos.y() - 1.1) {
                                 player.setDeltaMovement(player.getDeltaMovement().x, 0.125, player.getDeltaMovement().z);
                                 AetherPacketHandler.sendToServer(new AerbunnyPuffPacket(this.getId()));
                                 this.lastPos = null;


### PR DESCRIPTION
reduced the rate at which you can activate extra mid-air jumps so the aerbunny fits into the traversal progression better