### PR TITLE
fix: Bronze Dungeon generation avoids overlapping airborne dungeons

### DIFF
--- a/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
+++ b/src/generated/resources/.cache/103d9f3f36b01595f1aa5172191e60eff02e6924
@@ -1,4 +1,4 @@
-// 1.19.3	2023-02-16T01:39:28.0572369	Registries
+// 1.19.3	2023-02-19T17:26:14.828139	Registries
 f5deced101d2299e370ac067f29b5b355f28e634 data/aether/dimension/the_aether.json
 5655d4cd818dbc73a0baa2590d80dd274f85927d data/aether/dimension_type/the_aether.json
 9f53e09755713216c1110db9a66aa9703ec58a0a data/aether/worldgen/biome/skyroot_forest.json
@@ -59,6 +59,6 @@ c481c5e485a9933985435d13353759e599c775f2 data/aether/worldgen/placed_feature/tal
 aa7e50925cb356798844f47c61a11acc8f6d3ead data/aether/worldgen/structure/gold_dungeon.json
 5d95d82aa273637160cb12c0d82e31d722ace6cd data/aether/worldgen/structure/large_aercloud.json
 051484619a25e72347d4afeb30e0660291ad40c9 data/aether/worldgen/structure/silver_dungeon.json
-b87a1bee531973babec39c870b7d9f367bc53944 data/aether/worldgen/structure_set/bronze_dungeon.json
+751c8f99bd3407c1dba207991a30235a84b703cd data/aether/worldgen/structure_set/bronze_dungeon.json
 74c5f4f594d41486e3d8df1cbb87884d46154c50 data/aether/worldgen/structure_set/large_aercloud.json
 7d3446bf2d07cf5a14a1242206d65a96ed5f3853 data/aether/worldgen/structure_set/silver_and_gold_dungeons.json

--- a/src/generated/resources/data/aether/worldgen/structure_set/bronze_dungeon.json
+++ b/src/generated/resources/data/aether/worldgen/structure_set/bronze_dungeon.json
@@ -1,6 +1,10 @@
 {
   "placement": {
     "type": "minecraft:random_spread",
+    "exclusion_zone": {
+      "chunk_count": 4,
+      "other_set": "aether:silver_and_gold_dungeons"
+    },
     "salt": 32146754,
     "separation": 3,
     "spacing": 5

--- a/src/main/java/com/gildedgames/aether/data/resources/registries/AetherStructureSets.java
+++ b/src/main/java/com/gildedgames/aether/data/resources/registries/AetherStructureSets.java
@@ -1,10 +1,13 @@
 package com.gildedgames.aether.data.resources.registries;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.gildedgames.aether.Aether;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderGetter;
+import net.minecraft.core.Vec3i;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstapContext;
 import net.minecraft.resources.ResourceKey;
@@ -13,6 +16,7 @@ import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureSet;
 import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadStructurePlacement;
 import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadType;
+import net.minecraft.world.level.levelgen.structure.placement.StructurePlacement;
 
 public class AetherStructureSets {
     public static final ResourceKey<StructureSet> LARGE_AERCLOUD = createKey("large_aercloud");
@@ -26,10 +30,12 @@ public class AetherStructureSets {
     public static void bootstrap(BootstapContext<StructureSet> context) {
         HolderGetter<Structure> structures = context.lookup(Registries.STRUCTURE);
         context.register(LARGE_AERCLOUD, new StructureSet(structures.getOrThrow(AetherStructures.LARGE_AERCLOUD), new RandomSpreadStructurePlacement(6, 3, RandomSpreadType.LINEAR, 15536586)));
-        context.register(BRONZE_DUNGEON, new StructureSet(structures.getOrThrow(AetherStructures.BRONZE_DUNGEON), new RandomSpreadStructurePlacement(5, 3, RandomSpreadType.LINEAR, 32146754)));
-        context.register(SILVER_AND_GOLD_DUNGEONS, new StructureSet(List.of(
+
+        Holder<StructureSet> airborneSetHolder = context.register(SILVER_AND_GOLD_DUNGEONS, new StructureSet(List.of(
         		StructureSet.entry(structures.getOrThrow(AetherStructures.SILVER_DUNGEON), 3),
         		StructureSet.entry(structures.getOrThrow(AetherStructures.GOLD_DUNGEON), 1)),
         	new RandomSpreadStructurePlacement(34, 18, RandomSpreadType.LINEAR, 4325806)));
+
+        context.register(BRONZE_DUNGEON, new StructureSet(structures.getOrThrow(AetherStructures.BRONZE_DUNGEON), new RandomSpreadStructurePlacement(Vec3i.ZERO, StructurePlacement.FrequencyReductionMethod.DEFAULT, 1.0F, 32146754, Optional.of(new StructurePlacement.ExclusionZone(airborneSetHolder, 4)), 5, 3, RandomSpreadType.LINEAR)));
     }
 }


### PR DESCRIPTION
Bronze Dungeon generation avoid overlapping airborne dungeons, especially for cases when said airborne dungeon has also generated through the terrain