### PR TITLE
fix: Parachute can no longer auto-deploy when player already has a vehicle

### DIFF
--- a/src/main/java/com/gildedgames/aether/capability/player/AetherPlayerCapability.java
+++ b/src/main/java/com/gildedgames/aether/capability/player/AetherPlayerCapability.java
@@ -307,7 +307,7 @@ public class AetherPlayerCapability extends CapabilitySyncing implements AetherP
 		Player player = this.getPlayer();
 		Inventory inventory = this.getPlayer().getInventory();
 		Level level = player.level;
-		if (!player.isCreative() && !player.isShiftKeyDown() && !player.isFallFlying()) {
+		if (!player.isCreative() && !player.isShiftKeyDown() && !player.isFallFlying() && !player.isPassenger()) {
 			if (player.getDeltaMovement().y() < -1.5D) {
 				if (inventory.contains(AetherTags.Items.DEPLOYABLE_PARACHUTES)) {
 					for (ItemStack stack : inventory.items) {


### PR DESCRIPTION
closes #1007