### PR TITLE
build: Generalize the buildscript and make it use plugin DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ plugins {
     id 'com.modrinth.minotaur' version '2.+'
 }
 
-version = project.mc_version + '-' + project.aether_version + '-forge'
+version = "${project.mc_version}-${project.mod_version}-forge"
 group = 'com.gildedgames.aether' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'aether'
+archivesBaseName = project.mod_id
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17) // Mojang ships Java 8 to end users, so your mod should target Java 8.
 
@@ -28,7 +28,7 @@ minecraft {
             //property 'forge.logging.console.level', 'debug'
 
             mods {
-                aether {
+                "${project.mod_id}" {
                     source sourceSets.main
                 }
             }
@@ -41,7 +41,7 @@ minecraft {
             //property 'forge.logging.console.level', 'debug'
 
             mods {
-                aether {
+                "${project.mod_id}" {
                     source sourceSets.main
                 }
             }
@@ -53,12 +53,12 @@ minecraft {
             //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             //property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'aether', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/'), '--existing', file('src/generated/resources/')
+            args '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/'), '--existing', file('src/generated/resources/')
 
             environment 'target', 'fmluserdevdata'
 
             mods {
-                aether {
+                "${project.mod_id}" {
                     source sourceSets.main
                 }
             }
@@ -120,14 +120,13 @@ repositories {
 jar {
     manifest {
         attributes([
-                "Specification-Title"     : "The Aether",
+                "Specification-Title"     : project.mod_name,
                 "Specification-Vendor"    : "Gilded Games",
                 "Specification-Version"   : "1", // We are version 1 of ourselves
-                "Implementation-Title"    : "The Aether",
-                "Implementation-Version"  : "${version}",
+                "Implementation-Title"    : project.mod_name,
+                "Implementation-Version"  : project.jar.archiveVersion,
                 "Implementation-Vendor"   : "Gilded Games",
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-                "MixinConfigs"            : "aether.mixins.json"
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
 }
@@ -182,7 +181,7 @@ curseforge {
         changelogType = "markdown"
         addGameVersion("${project.mc_version}")
         mainArtifact(tasks.jar) {
-            displayName = "The Aether - Forge - ${version}"
+            displayName = "${project.mod_name} - Forge - ${version}"
             relations {
                 embeddedLibrary "curios"
                 optionalDependency "starlight-forge"
@@ -199,7 +198,7 @@ modrinth {
     projectId = "${project.modrinth_id}"
     versionNumber = "${version}"
     versionType = "${project.version_type}"
-    versionName = "The Aether - Forge - ${version}"
+    versionName = "${project.mod_name} - Forge - ${version}"
     changelog = new File("$rootDir/docs/CHANGELOG.md").text
     uploadFile = tasks.jar
     gameVersions = ["${project.mc_version}"]
@@ -212,8 +211,8 @@ modrinth {
 }
 
 mixin {
-    config "aether.mixins.json"
-    add sourceSets.main, "aether.refmap.json"
+    config "${project.mod_id}.mixins.json"
+    add sourceSets.main, "${project.mod_id}.refmap.json"
 }
 
 build {

--- a/build.gradle
+++ b/build.gradle
@@ -1,40 +1,12 @@
-buildscript {
-    repositories {
-        maven {
-            name 'Forge'
-            url 'https://maven.minecraftforge.net'
-        }
-        maven {
-            name 'Sponge'
-            url 'https://repo.spongepowered.org/maven'
-        }
-        maven {
-            name 'Parchment'
-            url 'https://maven.parchmentmc.org'
-        }
-        maven {
-            name 'Gradle'
-            url "https://plugins.gradle.org/m2/"
-        }
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
-        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7.+', changing: true
-        classpath group: 'org.parchmentmc', name: 'librarian', version: '1.+', changing: true
-        classpath group: 'io.github.0ffz', name: 'gpr-for-gradle', version: '1.+', changing: true
-        classpath group: 'gradle.plugin.com.matthewprenger', name: 'CurseGradle', version: '1.4.+', changing: true
-        classpath group: 'com.modrinth.minotaur', name: 'Minotaur', version: '2.+', changing: true
-    }
+plugins {
+    id 'maven-publish'
+    id 'net.minecraftforge.gradle' version '5.1.+'
+    id 'org.spongepowered.mixin' version '0.7.+'
+    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
+    id 'io.github.0ffz.github-packages' version '1.+'
+    id 'com.matthewprenger.cursegradle' version '1.4.+'
+    id 'com.modrinth.minotaur' version '2.+'
 }
-apply plugin: 'net.minecraftforge.gradle'
-apply plugin: 'org.spongepowered.mixin'
-apply plugin: 'org.parchmentmc.librarian.forgegradle'
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
-apply plugin: 'io.github.0ffz.github-packages'
-apply plugin: 'com.matthewprenger.cursegradle'
-apply plugin: 'com.modrinth.minotaur'
 
 version = project.mc_version + '-' + project.aether_version + '-forge'
 group = 'com.gildedgames.aether' // http://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,9 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Mod
-aether_version=0.6.1
+mod_id=aether
+mod_name=The Aether
+mod_version=0.6.1
 mc_version=1.19.4
 forge_version=45.0.40
 mappings=1.19.3-2023.03.12-1.19.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            var plugin = requested.id.toString()
+
+            switch (plugin) {
+                case 'org.spongepowered.mixin':
+                    useModule "org.spongepowered:mixingradle:${requested.version}"
+                    break
+            }
+        }
+    }
+    repositories {
+        gradlePluginPortal()
+        maven { url = 'https://maven.minecraftforge.net/' }
+        maven { url = 'https://repo.spongepowered.org/maven' }
+        maven { url = 'https://maven.parchmentmc.org' }
+    }
+}


### PR DESCRIPTION
# oh god he's back

Your `build.gradle` file is pretty nice and clean, but I want to help streamline its usage in the future, considering how this is not the only mod you lot will be working on. Here's a list of changes and their justifications:

- Plugins are now applied using the Gradle plugin DSL. This solves the deprecated usage of applying plugins manually via the `apply plugin:` syntax. It also thins out buildscript repositories (as they are technically now located in `settings.gradle`) and can make plugin management easier to maintain.
- Removed the "eclipse" plugin. This plugin is deprecated and should not be used, as it has shown to cause problems with MixinGradle and even Eclipse itself. The proper way to use Eclipse with a project is to imported it with "Existing Gradle Project", and it will generate the `classpath` and `project` files for you. `genEclipseRuns` functions as always and running the game posed no problems.
- The mod ID and name are now defined in `gradle.properties`. This solves the re-usage of "aether" and "The Aether" in the buildscript and thus generalizes it for usage in other mods.
- Removed `MixinConfigs` from the jar manifest. MixinGradle already does this for you. What it wouldn't do for you are Mixin connectors, which you are not using.

All changes were tested by building a jar file with all artifacts intact, including Jar-in-Jar artifacts, the mixin refmap, the jar manifest including the `MixinConfigs` property, and Gradle not literally imploding when I tried to do anything else.