### PR TITLE
fix: Prevent Aerbunny from despawning after used by player

### DIFF
--- a/src/main/java/com/aetherteam/aether/entity/passive/Aerbunny.java
+++ b/src/main/java/com/aetherteam/aether/entity/passive/Aerbunny.java
@@ -99,6 +99,7 @@ public class Aerbunny extends AetherAnimal {
         if (this.isOnGround() || !this.getFeetBlockState().isAir() || (this.getVehicle() != null && (this.getVehicle().isOnGround() || !this.getVehicle().getFeetBlockState().isAir()))) {
             this.lastPos = null;
         }
+        this.checkDespawn();
     }
 
     @Override
@@ -186,6 +187,7 @@ public class Aerbunny extends AetherAnimal {
                 this.setDeltaMovement(playerMovement.x * 5, playerMovement.y * 0.5 + 0.5, playerMovement.z * 5);
             } else if (this.startRiding(player)) {
                 AetherPlayer.get(player).ifPresent(aetherPlayer -> aetherPlayer.setMountedAerbunny(this));
+                this.setPersistenceRequired(); // now that a player is using this aerbunny, don't despawn it.
                 this.level.playSound(player, this, AetherSoundEvents.ENTITY_AERBUNNY_LIFT.get(), SoundSource.NEUTRAL, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
             }
             return InteractionResult.SUCCESS;


### PR DESCRIPTION
Fixes #1152.

Once an aerbunny is successfully mounted on a player, the persistence flag is marked to disallow natural despawning of the aerbunny.

One important caveat to note is that this implementation comes with the risk of creating an exploit that involves mounting multiple aerbunnies and preventing them all from despawning, causing server entity AI overload. Any suggestions to combat this are welcome.