### PR TITLE
Bugfix : No more Corner Stuck With Wind

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # The Aether - Forge - 1.19.4-1.0.0-beta.2
+
 Additions
+
 - Add internal resource pack for colorblind accessibility for Aercloud textures.
 - Add Jade compatibility for dungeon block tooltips.
 - Add Lootr compatibility for Chest Mimics.
@@ -12,6 +14,7 @@ Additions
 - Update uk_ua translation.
 
 Changes
+
 - Make Moas follow players by default after dismounting.
 - Increase walking speed for Moas.
 - Increase Moas vertical falling speed and decrease their horizontal flight speed when not mounted.
@@ -22,6 +25,7 @@ Changes
 - Disallow Aechor Plants being able to be launched by Gravitite Swords.
 
 Fixes
+
 - Fix Aerwhales and Zephyrs spawning indoors.
 - Fix Cockatrices spawning during thunderstorms when they shouldn't.
 - Fix Holystone Tools dropping Ambrosium from blocks without hardness.
@@ -54,4 +58,5 @@ Fixes
 - Fix various Aether entities not receiving knockback on death.
 
 # The Aether - Forge - 1.19.4-1.0.0-beta.1
+
 The Aether has undergone a full code rewrite between 1.12.2 and 1.19.4. A full changelog of everything that has been fixed and improved will be ready for full release, but as of beta we do not have one yet. For more information about the changes, you can ask around our Discord at https://discord.gg/aethermod.

--- a/src/main/java/com/aetherteam/aether/entity/monster/AbstractWhirlwind.java
+++ b/src/main/java/com/aetherteam/aether/entity/monster/AbstractWhirlwind.java
@@ -43,6 +43,7 @@ public abstract class AbstractWhirlwind extends Mob {
 
     public int lifeLeft;
     public int actionTimer;
+    public int stuckTick;
     public float movementAngle;
     public float movementCurve;
     protected boolean isPullingEntity = false;
@@ -109,6 +110,12 @@ public abstract class AbstractWhirlwind extends Mob {
     @Override
     public void aiStep() {
         if (!this.level.isClientSide) {
+            if (this.verticalCollision && !this.verticalCollisionBelow) {
+                this.stuckTick += 4;
+            } else if (this.stuckTick > 0) {
+                this.stuckTick--;
+            }
+
             if (this.getTarget() != null) {
                 this.actionTimer++;
             }
@@ -161,6 +168,9 @@ public abstract class AbstractWhirlwind extends Mob {
             if (!this.level.isEmptyBlock(this.blockPosition())) {
                 this.lifeLeft -= 50;
             }
+        }
+        if (this.stuckTick > 40) {
+            this.lifeLeft = 0;
         }
     }
 
@@ -223,11 +233,6 @@ public abstract class AbstractWhirlwind extends Mob {
 
     @Override
     protected boolean canRide(@Nonnull Entity vehicle) {
-        return false;
-    }
-
-    @Override
-    public boolean isAttackable() {
         return false;
     }
 

--- a/src/main/java/com/aetherteam/aether/entity/monster/AbstractWhirlwind.java
+++ b/src/main/java/com/aetherteam/aether/entity/monster/AbstractWhirlwind.java
@@ -227,6 +227,11 @@ public abstract class AbstractWhirlwind extends Mob {
     }
 
     @Override
+    public boolean isAttackable() {
+        return false;
+    }
+
+    @Override
     public void addAdditionalSaveData(@Nonnull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
         tag.putFloat("Movement Angle", this.movementAngle);


### PR DESCRIPTION
This pull request fixed Whirlwind stuck player if Whirlwind stuck in corner
(Such as player building house and terrain)

example:

https://user-images.githubusercontent.com/88538210/236647856-2fc71e36-2c4f-4833-892e-6730a48296e0.mp4

