### PR TITLE
fix: Account for days in Sun Altar client GUI (the slider no longer fucks off)

### DIFF
--- a/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
@@ -70,6 +70,8 @@ public class SunAltarBlockEntity extends BlockEntity implements Nameable {
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
@@ -277,6 +277,8 @@ public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity i
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/capability/time/AetherTimeCapability.java
+++ b/src/main/java/com/aetherteam/aether/capability/time/AetherTimeCapability.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.capability.time;
 
 import com.aetherteam.aether.AetherConfig;
+import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.aetherteam.aether.network.AetherPacketHandler;
 import com.aetherteam.aether.network.packet.client.EternalDayPacket;
 import net.minecraft.nbt.CompoundTag;
@@ -52,9 +53,9 @@ public class AetherTimeCapability implements AetherTime {
         long dayTime = level.getDayTime();
         if (this.getEternalDay() && !AetherConfig.COMMON.disable_eternal_day.get()) {
             if (dayTime != 18000L) {
-                long tempTime = dayTime % 72000L;
+                long tempTime = dayTime % (long) AetherDimensions.AETHER_TICKS_PER_DAY;
                 if (tempTime > 54000L) {
-                    tempTime -= 72000L;
+                    tempTime -= AetherDimensions.AETHER_TICKS_PER_DAY;
                 }
                 long target = (long) Mth.clamp(18000L - tempTime, -10, 10);
                 dayTime += target;

--- a/src/main/java/com/aetherteam/aether/client/gui/component/SunAltarSlider.java
+++ b/src/main/java/com/aetherteam/aether/client/gui/component/SunAltarSlider.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.client.gui.component;
 
 import com.aetherteam.aether.capability.AetherCapabilities;
+import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.aetherteam.aether.network.AetherPacketHandler;
 import com.aetherteam.aether.network.packet.server.SunAltarUpdatePacket;
 import net.minecraft.client.gui.components.AbstractSliderButton;
@@ -25,7 +26,7 @@ public class SunAltarSlider extends AbstractSliderButton {
 
     @Override
     protected void applyValue() {
-        long time = (long) (this.value * 72000);
+        long time = (long) (this.value * AetherDimensions.AETHER_TICKS_PER_DAY);
         level.getCapability(AetherCapabilities.AETHER_TIME_CAPABILITY).ifPresent(aetherTime -> {
             AetherPacketHandler.sendToServer(new SunAltarUpdatePacket(time));
         });

--- a/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
+++ b/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
@@ -25,7 +25,7 @@ public class SunAltarScreen extends Screen {
     @Override
     public void init() {
         super.init();
-        double value = (this.minecraft.level.getDayTime() % (long) AetherDimensions.AETHER_TICKS_PER_DAY) / 72000D;
+        double value = (this.minecraft.level.getDayTime() % (long) AetherDimensions.AETHER_TICKS_PER_DAY) / (double) AetherDimensions.AETHER_TICKS_PER_DAY;
         this.addRenderableWidget(new SunAltarSlider(this.minecraft.level, this.width / 2 - 75, this.height / 2, 150, 20, Component.translatable("gui." + Aether.MODID + ".sun_altar.time"), value));
     }
 

--- a/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
+++ b/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
@@ -2,6 +2,7 @@ package com.aetherteam.aether.client.gui.screen;
 
 import com.aetherteam.aether.Aether;
 import com.aetherteam.aether.client.gui.component.SunAltarSlider;
+import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.screens.Screen;
@@ -24,7 +25,7 @@ public class SunAltarScreen extends Screen {
     @Override
     public void init() {
         super.init();
-        double value = (this.minecraft.level.getDayTime() % 72000L) / 72000D;
+        double value = (this.minecraft.level.getDayTime() % (long) AetherDimensions.AETHER_TICKS_PER_DAY) / 72000D;
         this.addRenderableWidget(new SunAltarSlider(this.minecraft.level, this.width / 2 - 75, this.height / 2, 150, 20, Component.translatable("gui." + Aether.MODID + ".sun_altar.time"), value));
     }
 

--- a/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
+++ b/src/main/java/com/aetherteam/aether/client/gui/screen/SunAltarScreen.java
@@ -24,7 +24,7 @@ public class SunAltarScreen extends Screen {
     @Override
     public void init() {
         super.init();
-        double value = this.minecraft.level.getDayTime() / 72000D;
+        double value = (this.minecraft.level.getDayTime() % 72000L) / 72000D;
         this.addRenderableWidget(new SunAltarSlider(this.minecraft.level, this.width / 2 - 75, this.height / 2, 150, 20, Component.translatable("gui." + Aether.MODID + ".sun_altar.time"), value));
     }
 

--- a/src/main/java/com/aetherteam/aether/client/renderer/level/AetherSkyRenderEffects.java
+++ b/src/main/java/com/aetherteam/aether/client/renderer/level/AetherSkyRenderEffects.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.client.renderer.level;
 
 import com.aetherteam.aether.AetherConfig;
+import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.aetherteam.aether.mixin.mixins.client.accessor.LevelRendererAccessor;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -331,7 +332,7 @@ public class AetherSkyRenderEffects extends DimensionSpecialEffects //todo: futu
      */
     private void drawCelestialBodies(float pPartialTick, PoseStack pPoseStack, ClientLevel world, BufferBuilder bufferbuilder) {
         // This code determines the current angle of the sun and moon and determines whether they should be visible or not.
-        long dayTime = world.getDayTime() % 72000L;
+        long dayTime = world.getDayTime() % (long) AetherDimensions.AETHER_TICKS_PER_DAY;
         float sunOpacity;
         float moonOpacity;
         if (dayTime > 71400L) {

--- a/src/main/java/com/aetherteam/aether/data/resources/registries/AetherDimensions.java
+++ b/src/main/java/com/aetherteam/aether/data/resources/registries/AetherDimensions.java
@@ -28,6 +28,8 @@ public class AetherDimensions {
 	public static final ResourceKey<Level> AETHER_LEVEL = ResourceKey.create(Registries.DIMENSION, AETHER_LEVEL_ID);
 	// LevelStem - The dimension during lifecycle start and datagen.
 	public static final ResourceKey<LevelStem> AETHER_LEVEL_STEM = ResourceKey.create(Registries.LEVEL_STEM, AETHER_LEVEL_ID);
+	// Time in ticks of how long a day/night cycle lasts.
+	public static final int AETHER_TICKS_PER_DAY = (24000) * 3; // too scared to call Level.TICKS_PER_DAY because of static init problems, but just know this is Level.TICKS_PER_DAY * 3
 
 	public static void bootstrapDimensionType(BootstapContext<DimensionType> context) {
 		context.register(AETHER_DIMENSION_TYPE, new DimensionType(

--- a/src/main/java/com/aetherteam/aether/event/listeners/DimensionListener.java
+++ b/src/main/java/com/aetherteam/aether/event/listeners/DimensionListener.java
@@ -144,7 +144,7 @@ public class DimensionListener {
         ServerLevel level = (ServerLevel) event.getLevel();
         if (level.dimensionType().effectsLocation().equals(AetherDimensions.AETHER_DIMENSION_TYPE.location())) {
             long time = event.getNewTime() + 48000L;
-            event.setTimeAddition(time - time % 72000L);
+            event.setTimeAddition(time - time % (long) AetherDimensions.AETHER_TICKS_PER_DAY);
 
             ServerLevelAccessor serverLevelAccessor = (ServerLevelAccessor) level;
             serverLevelAccessor.aether$getServerLevelData().setRainTime(0);

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/common/DimensionTypeMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/common/DimensionTypeMixin.java
@@ -23,7 +23,7 @@ public class DimensionTypeMixin {
     @Inject(at = @At("HEAD"), method = "timeOfDay", cancellable = true)
     private void timeOfDay(long dayTime, CallbackInfoReturnable<Float> cir) {
         if (this.effectsLocation.equals(AetherDimensions.AETHER_DIMENSION_TYPE.location())) {
-            double d0 = Mth.frac(dayTime / 72000.0D - 0.25D);
+            double d0 = Mth.frac(dayTime / (double) AetherDimensions.AETHER_TICKS_PER_DAY - 0.25D);
             double d1 = 0.5D - Math.cos(d0 * Math.PI) / 2.0D;
             cir.setReturnValue((float)(d0 * 2.0D + d1) / 3.0F);
         }
@@ -32,7 +32,7 @@ public class DimensionTypeMixin {
     @Inject(at = @At("HEAD"), method = "moonPhase", cancellable = true)
     private void moonPhase(long dayTime, CallbackInfoReturnable<Integer> cir) {
         if (this.effectsLocation.equals(AetherDimensions.AETHER_DIMENSION_TYPE.location())) {
-            cir.setReturnValue((int) (dayTime / 72000L % 8L + 8L) % 8);
+            cir.setReturnValue((int) (dayTime / (long) AetherDimensions.AETHER_TICKS_PER_DAY % 8L + 8L) % 8);
         }
     }
 }

--- a/src/main/java/com/aetherteam/aether/network/packet/server/SunAltarUpdatePacket.java
+++ b/src/main/java/com/aetherteam/aether/network/packet/server/SunAltarUpdatePacket.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.network.packet.server;
 
 import com.aetherteam.aether.AetherConfig;
+import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.aetherteam.aether.network.AetherPacket;
 import com.aetherteam.aether.api.SunAltarWhitelist;
 import net.minecraft.network.FriendlyByteBuf;
@@ -27,8 +28,8 @@ public record SunAltarUpdatePacket(long dayTime) implements AetherPacket {
     public void execute(Player playerEntity) {
         if (playerEntity != null && playerEntity.level instanceof ServerLevel level && (!AetherConfig.COMMON.sun_altar_whitelist.get() || playerEntity.hasPermissions(4) || SunAltarWhitelist.INSTANCE.isWhiteListed(playerEntity.getGameProfile()))) {
             // get how many days have passed in the world first, then add to it.
-            var dayBase = level.getDayTime() / 72000L;
-            var dayTime = (dayBase * 72000L) + this.dayTime;
+            var dayBase = level.getDayTime() / (long) AetherDimensions.AETHER_TICKS_PER_DAY;
+            var dayTime = (dayBase * AetherDimensions.AETHER_TICKS_PER_DAY) + this.dayTime;
 
             level.setDayTime(dayTime);
             level.getServer().getPlayerList().broadcastAll(new ClientboundSetTimePacket(level.getGameTime(), level.getDayTime(), level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)), level.dimension());

--- a/src/main/java/com/aetherteam/aether/network/packet/server/SunAltarUpdatePacket.java
+++ b/src/main/java/com/aetherteam/aether/network/packet/server/SunAltarUpdatePacket.java
@@ -26,7 +26,11 @@ public record SunAltarUpdatePacket(long dayTime) implements AetherPacket {
     @Override
     public void execute(Player playerEntity) {
         if (playerEntity != null && playerEntity.level instanceof ServerLevel level && (!AetherConfig.COMMON.sun_altar_whitelist.get() || playerEntity.hasPermissions(4) || SunAltarWhitelist.INSTANCE.isWhiteListed(playerEntity.getGameProfile()))) {
-            level.setDayTime(this.dayTime);
+            // get how many days have passed in the world first, then add to it.
+            var dayBase = level.getDayTime() / 72000L;
+            var dayTime = (dayBase * 72000L) + this.dayTime;
+
+            level.setDayTime(dayTime);
             level.getServer().getPlayerList().broadcastAll(new ClientboundSetTimePacket(level.getGameTime(), level.getDayTime(), level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)), level.dimension());
         }
     }

--- a/src/main/java/com/aetherteam/aether/world/foliageplacer/GoldenOakFoliagePlacer.java
+++ b/src/main/java/com/aetherteam/aether/world/foliageplacer/GoldenOakFoliagePlacer.java
@@ -42,7 +42,7 @@ public class GoldenOakFoliagePlacer extends FoliagePlacer {
      * The coordinates are passed in as absolute value, and should be within [0, {@code range}].
      */
     protected boolean shouldSkipLocation(RandomSource random, int localX, int localY, int localZ, int range, boolean large) {
-        Aether.LOGGER.debug("Local Y:" + (localY));
+        //Aether.LOGGER.debug("Local Y:" + (localY));
         return localX*localX + (localY+2)*(localY+2) + localZ*localZ > 12 + random.nextInt(5);
     }
 }


### PR DESCRIPTION
Fixes #1353.

Changes:
- Accounts for previous days in the client GUI.
- Retains previous days in the packet handler.
- Global variable added to `AetherDimensions`: `AETHER_TICKS_PER_DAY`
  - Updated usages of `72000` to this global variable. This helps improve code readability and understanding of what certain aspects of it are written for.

![](https://cdn.moddinglegacy.com/084550387907945244-java_P2Fypbe16i.png)