### PR TITLE
fix: Null-check nullable tag on client BlockEntity packet

### DIFF
--- a/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
@@ -70,6 +70,8 @@ public class SunAltarBlockEntity extends BlockEntity implements Nameable {
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
@@ -277,6 +277,8 @@ public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity i
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }


### PR DESCRIPTION
Prevents client from panicking when loading block entities. Also important because it could've potentially been breaking the logic within the lambda in the parent method (found at the bottom of the stacktrace of this PR).

```
[17:42:07] [Render thread/ERROR] [minecraft/BlockableEventLoop]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "net.minecraft.nbt.CompoundTag.contains(String)" because "pTag" is null
	at net.minecraft.world.level.block.entity.BlockEntity.load(BlockEntity.java:57) ~[forge-1.19.4-45.0.47_mapped_parchment_1.19.3-2023.03.12-1.19.4.jar:?] {re:classloading,re:mixin}
	at com.aetherteam.aether.blockentity.SunAltarBlockEntity.load(SunAltarBlockEntity.java:59) ~[main/:?] {re:classloading}
	at com.aetherteam.aether.blockentity.SunAltarBlockEntity.handleUpdateTag(SunAltarBlockEntity.java:46) ~[main/:?] {re:classloading}
	at com.aetherteam.aether.blockentity.SunAltarBlockEntity.onDataPacket(SunAltarBlockEntity.java:73) ~[main/:?] {re:classloading}
	at net.minecraft.client.multiplayer.ClientPacketListener.lambda$handleBlockEntityData$6(ClientPacketListener.java:1258) ~[forge-1.19.4-45.0.47_mapped_parchment_1.19.3-2023.03.12-1.19.4.jar:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	// ...
	// a bunch of other useless shit on god fr :miserable:
```