### PR TITLE
refactor: Suppress unnecessary debug logging

### DIFF
--- a/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/SunAltarBlockEntity.java
@@ -70,6 +70,8 @@ public class SunAltarBlockEntity extends BlockEntity implements Nameable {
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
+++ b/src/main/java/com/aetherteam/aether/blockentity/TreasureChestBlockEntity.java
@@ -277,6 +277,8 @@ public class TreasureChestBlockEntity extends RandomizableContainerBlockEntity i
     @Override
     public void onDataPacket(Connection connection, ClientboundBlockEntityDataPacket packet) {
         CompoundTag compound = packet.getTag();
-        this.handleUpdateTag(compound);
+        if (compound != null) {
+            this.handleUpdateTag(compound);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/world/foliageplacer/GoldenOakFoliagePlacer.java
+++ b/src/main/java/com/aetherteam/aether/world/foliageplacer/GoldenOakFoliagePlacer.java
@@ -42,7 +42,7 @@ public class GoldenOakFoliagePlacer extends FoliagePlacer {
      * The coordinates are passed in as absolute value, and should be within [0, {@code range}].
      */
     protected boolean shouldSkipLocation(RandomSource random, int localX, int localY, int localZ, int range, boolean large) {
-        Aether.LOGGER.debug("Local Y:" + (localY));
+        //Aether.LOGGER.debug("Local Y:" + (localY));
         return localX*localX + (localY+2)*(localY+2) + localZ*localZ > 12 + random.nextInt(5);
     }
 }


### PR DESCRIPTION
Suppresses debug logging from the `shouldSkipLocation` in `GoldenOakFoliagePlacer`.

- Debug logging can get in the way of developers who use actual debug logging frequently (me) in dev environment so that it doesn't show up in production. (fun fact: debug logging is pretty important if you want to keep track of mixin applications)
- keeping this line uncommented will likely plague `debug.log` files sent by players who use this mod