### PR TITLE
improv: New IS_COLD Damage type for Sun Spirit

### DIFF
--- a/src/generated/resources/.cache/0164a9e83927622ad492ab881424439b3f361cdf
+++ b/src/generated/resources/.cache/0164a9e83927622ad492ab881424439b3f361cdf
@@ -1,4 +1,5 @@
-// 1.19.4	2023-03-18T15:59:38.7181707	Tags for minecraft:damage_type mod id aether
+// 1.19.4	2023-05-16T17:35:58.4796734	Tags for minecraft:damage_type mod id aether
+349770fa7a71d7f6c642e562b1052607ed17b73d data/aether/tags/damage_type/is_cold.json
 476b0d58a4b22583f5e50634bea23b5679f23bc6 data/minecraft/tags/damage_type/bypasses_armor.json
 c1433810244ba27b66a343ff3535634d43410c04 data/minecraft/tags/damage_type/damages_helmet.json
 755ea6dcc4c62717e53bf07308ad7e3b6df4a30a data/minecraft/tags/damage_type/is_fire.json

--- a/src/generated/resources/data/aether/tags/damage_type/is_cold.json
+++ b/src/generated/resources/data/aether/tags/damage_type/is_cold.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "aether:ice_crystal"
+  ]
+}

--- a/src/main/java/com/aetherteam/aether/AetherTags.java
+++ b/src/main/java/com/aetherteam/aether/AetherTags.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether;
 
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.entity.EntityType;
@@ -188,6 +189,14 @@ public class AetherTags {
 
 		private static TagKey<Structure> tag(String name) {
 			return TagKey.create(Registries.STRUCTURE, new ResourceLocation(Aether.MODID, name));
+		}
+	}
+
+	public static class DamageTypes {
+		public static final TagKey<DamageType> IS_COLD = tag("is_cold");
+
+		private static TagKey<DamageType> tag(String name) {
+			return TagKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(Aether.MODID, name));
 		}
 	}
 }

--- a/src/main/java/com/aetherteam/aether/data/generators/tags/AetherDamageTypeTagData.java
+++ b/src/main/java/com/aetherteam/aether/data/generators/tags/AetherDamageTypeTagData.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.data.generators.tags;
 
 import com.aetherteam.aether.Aether;
+import com.aetherteam.aether.AetherTags;
 import com.aetherteam.aether.data.resources.AetherDamageTypes;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
@@ -36,6 +37,9 @@ public class AetherDamageTypeTagData extends TagsProvider<DamageType> {
                 AetherDamageTypes.FIRE_CRYSTAL,
                 AetherDamageTypes.ICE_CRYSTAL,
                 AetherDamageTypes.THUNDER_CRYSTAL
+        );
+        this.tag(AetherTags.DamageTypes.IS_COLD).add(
+                AetherDamageTypes.ICE_CRYSTAL
         );
     }
 }

--- a/src/main/java/com/aetherteam/aether/entity/monster/dungeon/boss/SunSpirit.java
+++ b/src/main/java/com/aetherteam/aether/entity/monster/dungeon/boss/SunSpirit.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.entity.monster.dungeon.boss;
 
 import com.aetherteam.aether.AetherConfig;
+import com.aetherteam.aether.AetherTags;
 import com.aetherteam.aether.api.BossRoomTracker;
 import com.aetherteam.aether.block.AetherBlocks;
 import com.aetherteam.aether.capability.player.AetherPlayer;
@@ -186,7 +187,7 @@ public class SunSpirit extends PathfinderMob implements BossMob<SunSpirit>, Enem
 
     @Override
     public boolean isInvulnerableTo(DamageSource source) {
-        return this.isRemoved() || !source.is(DamageTypeTags.BYPASSES_INVULNERABILITY) && !source.getMsgId().equals("aether.ice_crystal");
+        return this.isRemoved() || !source.is(DamageTypeTags.BYPASSES_INVULNERABILITY) && !source.is(AetherTags.DamageTypes.IS_COLD);
     }
 
     /**


### PR DESCRIPTION
Adds a new DamageType tag `IS_COLD` to the Aether and changes the Sun Spirit damage check accordingly.

- By expanding the invulnerability check to a tag instead of the single Ice Crystal, the Sun Spirit can now take damage by other possible items added by addons or other mods.
- It doesn't change the core functionality and extends possibilities.
- It can be made configurable in case someone doesn't want other damage options.
