### PR TITLE
feat: Add debug mcfunctions

### DIFF
--- a/src/main/resources/data/aether/functions/dev_new_world.mcfunction
+++ b/src/main/resources/data/aether/functions/dev_new_world.mcfunction
@@ -1,0 +1,3 @@
+# Put equipment on the player and enter the Aether
+function aether:suit_up
+execute in aether:the_aether run teleport ~ ~ ~

--- a/src/main/resources/data/aether/functions/dev_powerwash_chunk.mcfunction
+++ b/src/main/resources/data/aether/functions/dev_powerwash_chunk.mcfunction
@@ -1,0 +1,2 @@
+fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #minecraft:dirt
+fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #forge:stone

--- a/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
+++ b/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
@@ -1,0 +1,3 @@
+execute in aether:the_aether run tp @p ~ ~ ~
+gamemode spectator @p
+effect give @p minecraft:night_vision 9999

--- a/src/main/resources/data/aether/functions/suit_up.mcfunction
+++ b/src/main/resources/data/aether/functions/suit_up.mcfunction
@@ -1,0 +1,14 @@
+# Suits up the player with equipment that won't break for battle.
+give @p aether:zanite_pickaxe{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+give @p aether:zanite_sword{Enchantments:[{id:"minecraft:unbreaking", lvl:10}]}
+
+# If the player doesn't already have armor, equip them with gravitite.
+execute unless data entity @p Inventory[{Slot:100b}] run item replace entity @p armor.feet with aether:gravitite_boots{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+execute unless data entity @p Inventory[{Slot:101b}] run item replace entity @p armor.legs with aether:gravitite_leggings{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+execute unless data entity @p Inventory[{Slot:102b}] run item replace entity @p armor.chest with aether:gravitite_chestplate{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+execute unless data entity @p Inventory[{Slot:103b}] run item replace entity @p armor.head with aether:gravitite_helmet{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+execute unless data entity @p ForgeCaps."curios:inventory".Curios[{Identifier:"aether_gloves"}].StacksHandler.Stacks.Items[0] run curios replace aether_gloves 0 @p with aether:gravitite_gloves{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+
+give @p aether:skyroot_water_bucket
+give @p aether:enchanted_berry 64
+give @p aether:healing_stone 64


### PR DESCRIPTION
Functions in Minecraft are a convenient way to add developer utilities without exposing them to the average player. This PR adds a couple of functions from Twilight Forest, as well as our own for instantly teleporting to the Aether and suiting up with equipment.