### PR TITLE
fix: If the moaType is null, use the blue type as fallback for save data

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ The Aether Team presents the original Aether mod! Up to date for modern Minecraf
 [![YouTube](https://img.shields.io/badge/youtube-@DevAether-blue?color=FF0000&label=youtube&logo=youtube&style=flat-square)](https://www.youtube.com/@DevAether)
 [![Twitch](https://img.shields.io/twitch/status/theaetherteam?logo=twitch&style=flat-square&logoColor=white)](https://www.twitch.tv/theaetherteam)
 [![Reddit](https://img.shields.io/reddit/subreddit-subscribers/TheAether?color=FF4500&label=reddit&logo=reddit&style=flat-square&logoColor=white)](https://www.reddit.com/r/TheAether/)
-[![wiki.gg](https://custom-icon-badges.demolab.com/badge/wiki-aether-green?logo=wikigg&style=flat-square&color=FF1980)](https://aether.wiki.gg/)
+[![wiki.gg](https://custom-icon-badges.demolab.com/badge/wiki.gg-aether-green?logo=wikigg&style=flat-square&color=FF1980)](https://aether.wiki.gg/)
 
 If you enjoy our work, [please consider making a pledge](https://patreon.com/TheAetherTeam) today to help fund development. Every pledge goes directly into our development process and services, enabling us to continue making the Minecraft mods you know and love.
 

--- a/src/main/java/com/aetherteam/aether/entity/passive/Moa.java
+++ b/src/main/java/com/aetherteam/aether/entity/passive/Moa.java
@@ -57,6 +57,7 @@ import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -696,7 +697,7 @@ public class Moa extends MountableAnimal implements WingedBird {
 			tag.putUUID("MoaUUID", this.getMoaUUID());
 		}
 		tag.putBoolean("IsBaby", this.isBaby());
-		tag.putString("MoaType", this.getMoaType().toString());
+		tag.putString("MoaType", Objects.requireNonNullElse(this.getMoaType(), AetherMoaTypes.BLUE).toString());
 		if (this.getRider() != null) {
 			tag.putUUID("Rider", this.getRider());
 		}


### PR DESCRIPTION
I have a world in which I experienced frequent crashes with the following error:
```
The game crashed whilst saving entity nbt
Error: java.lang.NullPointerException: Cannot invoke "com.aetherteam.aether.api.registers.MoaType.toString()" because the return value of "com.aetherteam.aether.entity.passive.Moa.getMoaType()" is null
```

I noticed that in `Moa#addAdditionalSaveData`, the `toString()` method is called on `getMoaType()` without making sure the method returns a non-null value. I also noticed that the return value of `getMoaType()` is treated as potentially null in many places around the Moa class, and that the blue Moa type is often used as a fallback for those cases. I therefore extended this pattern here, and after some testing it seems like the crashes no longer occur. 

---

I agree to the Contributor License Agreement (CLA).

