### PR TITLE
refactor: Manually cancel BossEventProgress after it is posted

### DIFF
--- a/src/main/java/com/aetherteam/aether/client/event/listeners/GuiListener.java
+++ b/src/main/java/com/aetherteam/aether/client/event/listeners/GuiListener.java
@@ -122,7 +122,8 @@ public class GuiListener {
 		if (BOSS_EVENTS.contains(bossEvent.getId())) {
 			GuiHooks.drawBossHealthBar(event.getPoseStack(), event.getX(), event.getY(), bossEvent);
 			event.setIncrement(event.getIncrement() + 13);
-			event.setCanceled(true);
+			// This event is cancelled in BossHealthOverlayMixin. see it for more info.
+			//event.setCanceled(true);
 		}
 	}
 

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/client/BossHealthOverlayMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/client/BossHealthOverlayMixin.java
@@ -1,0 +1,21 @@
+package com.aetherteam.aether.mixin.mixins.client;
+
+import com.aetherteam.aether.client.event.listeners.GuiListener;
+import net.minecraft.client.gui.components.BossHealthOverlay;
+import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(BossHealthOverlay.class)
+public class BossHealthOverlayMixin {
+    /**
+     * Ultimately cancels the {@link CustomizeGuiOverlayEvent.BossEventProgress} GUI event after all event listeners
+     * have had a turn with it. Made as a workaround for Jade's boss bar pushdown.
+     */
+    @ModifyVariable(at = @At(value = "STORE"), method = "render", index = 7)
+    private CustomizeGuiOverlayEvent.BossEventProgress render(CustomizeGuiOverlayEvent.BossEventProgress event) {
+        event.setCanceled(GuiListener.BOSS_EVENTS.contains(event.getBossEvent().getId()));
+        return event;
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -39,6 +39,7 @@
   "client": [
     "client.AbstractClientPlayerMixin",
     "client.AdvancementToastMixin",
+    "client.BossHealthOverlayMixin",
     "client.ConnectScreenMixin",
     "client.CreateWorldScreenMixin",
     "client.LocalPlayerMixin",


### PR DESCRIPTION
Closes #1570.

Jade's boss bar pushdown works by checking if `CustomizeGuiOverlayEvent.BossEventProgress` is canceled. This means that, technically, we're the ones breaking the rules by disabling the normal boss bar and rending our own on top of it.

Instead of refactoring Aether's boss bar system to use a mixin into `BossHealthOverlay` based on the results of the event (although you can do that if you want if you decide that that is a better solution over this), this PR's solution is to allow the event to play out to all listeners before setting the event as canceled after the event result has been stored in its variable (see `BossHealthOverlay:37`). That way, event listeners can act as if the Aether's boss bar is the normal boss bar (since we already set the increment in our listener) without needing to rely on the event being canceled.

![proof that it works](https://cdn.moddinglegacy.com/451572592188667821-java_Lv8qxpeQFN.png)