### PR TITLE
build: Cleanup jar artifact building and publishing pointers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,10 @@ tasks.jarJar.configure {
     archiveClassifier = ""
 }
 
+// ensure jars are reobf'ed before confirming artifact files
+jar.finalizedBy('reobfJar')
+tasks.jarJar.finalizedBy('reobfJarJar')
+
 tasks.named(sourceSets.main.compileJavaTaskName) {
     outputs.file("${it.temporaryDir}/${it.name}-refmap.json").withPropertyName("mixin refmap")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,10 @@ artifacts {
     archives sourcesJar
 }
 
+tasks.jar.configure {
+    archiveClassifier = "no-embeds"
+}
+
 tasks.jarJar.configure {
     archiveClassifier = ""
 }
@@ -155,6 +159,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             artifactId project.archivesBaseName
+            artifact project.tasks.jarJar
             artifact jar
             artifact sourcesJar
         }

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,6 @@ publishing {
         mavenJava(MavenPublication) {
             artifactId project.archivesBaseName
             artifact project.tasks.jarJar
-            artifact jar
             artifact sourcesJar
         }
     }

--- a/src/main/java/com/aetherteam/aether/client/event/listeners/GuiListener.java
+++ b/src/main/java/com/aetherteam/aether/client/event/listeners/GuiListener.java
@@ -122,7 +122,8 @@ public class GuiListener {
 		if (BOSS_EVENTS.contains(bossEvent.getId())) {
 			GuiHooks.drawBossHealthBar(event.getPoseStack(), event.getX(), event.getY(), bossEvent);
 			event.setIncrement(event.getIncrement() + 13);
-			event.setCanceled(true);
+			// This event is cancelled in BossHealthOverlayMixin. see it for more info.
+			//event.setCanceled(true);
 		}
 	}
 

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/client/BossHealthOverlayMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/client/BossHealthOverlayMixin.java
@@ -1,0 +1,21 @@
+package com.aetherteam.aether.mixin.mixins.client;
+
+import com.aetherteam.aether.client.event.listeners.GuiListener;
+import net.minecraft.client.gui.components.BossHealthOverlay;
+import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(BossHealthOverlay.class)
+public class BossHealthOverlayMixin {
+    /**
+     * Ultimately cancels the {@link CustomizeGuiOverlayEvent.BossEventProgress} GUI event after all event listeners
+     * have had a turn with it. Made as a workaround for Jade's boss bar pushdown.
+     */
+    @ModifyVariable(at = @At(value = "STORE"), method = "render", index = 7)
+    private CustomizeGuiOverlayEvent.BossEventProgress render(CustomizeGuiOverlayEvent.BossEventProgress event) {
+        event.setCanceled(GuiListener.BOSS_EVENTS.contains(event.getBossEvent().getId()));
+        return event;
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -39,6 +39,7 @@
   "client": [
     "client.AbstractClientPlayerMixin",
     "client.AdvancementToastMixin",
+    "client.BossHealthOverlayMixin",
     "client.ConnectScreenMixin",
     "client.CreateWorldScreenMixin",
     "client.LocalPlayerMixin",


### PR DESCRIPTION
This is another Gradle cleanup PR that I'd like to propose. I noticed that with the way your `build.gradle` system is set up, the `build` and `publish` tasks *must* act in tandem with each other. This can also be cause for concern if there is a desync in the source code but there is no check for it in the `publish`, since it could publish the old jar file without checking sources *and* properly reobfuscating the jar file.

To solve this, I've allowed the `jar` and `jarJar` tasks to act independently of each other. In the publishing configuration, I've added `artifact project.tasks.jarJar`, which will allow Gradle to grab the file specified manually by the `jarJar` task. Additionally, I've configured the base `jar` task to have a classifier of "no-embeds". This leaves the normal, non-embedded jar file intact in case you want to play around with it more for debugging purposes without the need to override it with the embedded jar file.

Finally, I've added two lines to force Gradle to ensure that the "jar" and "jarJar" archive tasks are always followed up by their reobfuscation counterpart. This might solve any additional reobfuscation problems with building the project in the future.