### PR TITLE
build: Publish an obfuscated sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             artifactId project.archivesBaseName
-            artifact jar
-            artifact sourcesJar
+            artifact project.tasks.jarJar
+            artifact sourceJar
         }
     }
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
     id 'org.spongepowered.mixin' version '0.7.+'
     id 'org.parchmentmc.librarian.forgegradle' version '1.+'
+    id 'org.moddingx.modgradle.sourcejar' version '3.+'
     id 'io.github.0ffz.github-packages' version '1.+'
     id 'com.matthewprenger.cursegradle' version '1.4.+'
     id 'com.modrinth.minotaur' version '2.+'
@@ -130,15 +131,6 @@ jar {
     }
 }
 
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allJava
-}
-
-artifacts {
-    archives sourcesJar
-}
-
 tasks.jarJar.configure {
     archiveClassifier = ""
 }
@@ -156,7 +148,7 @@ publishing {
         mavenJava(MavenPublication) {
             artifactId project.archivesBaseName
             artifact jar
-            artifact sourcesJar
+            artifact sourceJar
         }
     }
     repositories {

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,8 +83,7 @@ Then load it through your dependencies, with `project.aether_version` specified 
 ```
 dependencies {
   ...
-  compileOnly "com.aetherteam.aether:aether:${project.aether_version}"
-  runtimeOnly fg.deobf("com.aetherteam.aether:aether:${project.aether_version}")
+  implementation fg.deobf("com.aetherteam.aether:aether:${project.aether_version}")
   ...
 }
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,12 @@ pluginManagement {
         eachPlugin {
             var plugin = requested.id.toString()
 
+            // ModGradle
+            if (plugin.startsWith('org.moddingx.modgradle.')) {
+                useModule "org.moddingx:ModGradle:${requested.version}"
+            }
+
+            // everything else
             switch (plugin) {
                 case 'org.spongepowered.mixin':
                     useModule "org.spongepowered:mixingradle:${requested.version}"
@@ -15,5 +21,6 @@ pluginManagement {
         maven { url = 'https://maven.minecraftforge.net/' }
         maven { url = 'https://repo.spongepowered.org/maven' }
         maven { url = 'https://maven.parchmentmc.org' }
+        maven { url = 'https://maven.moddingx.org' }
     }
 }


### PR DESCRIPTION
Publishing an obfuscated sources jar file solves the need to manually specify to Gradle to only deobfuscate the runtime and use the compile normally. ForgeGradle has the capability to deobfuscate source jar files and it does so rather well. This also allows addon developers to work with other mappings of choice (which may be important for those who still use Yarn, for whatever reason).

This is done using [ModGradle's SourceJar](https://github.com/ModdingX/ModGradle/blob/master/docs/sourcejar.md) Gradle plugin, which does all of the heavy lifting for you (including creating the "sourceJar" task). I've edited the README file to account for this change if you wish to implement it.