### PR TITLE
build: Upgrade to ForgeGradle 6 and switch to Sugarcane mappings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - setup
       - run: |
-          ./gradlew publish
+          gradle publish
 
 commands:
   setup:
@@ -26,7 +26,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: ./gradlew build --parallel --build-cache --console=plain
+            - run: gradle build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - setup
       - run: |
-          gradle publish
+          chmod +x ./gradlew
+          ./gradlew publish
 
 commands:
   setup:
@@ -26,7 +27,10 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradle build --parallel --console=plain
+            - run:
+                name: chmod permissions
+                command: chmod +x ./gradlew
+            - run: ./gradlew build --parallel --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - setup
       - run: |
-          gradlew publish
+          ./gradlew publish
 
 commands:
   setup:
@@ -26,7 +26,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradlew build --parallel --build-cache --console=plain
+            - run: ./gradlew build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
     steps:
       - checkout
       - gradle/with_cache:
-          cache_key: 'v8'
+          cache_key: 'v9'
           steps:
             - run: gradle build --parallel --build-cache --console=plain
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - setup
       - run: |
-          gradle publish
+          gradlew publish
 
 commands:
   setup:
@@ -26,7 +26,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradle build --parallel --build-cache --console=plain
+            - run: gradlew build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradle build --parallel --build-cache --console=plain
+            - run: gradle build --parallel --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,6 +148,9 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
+            - run:
+                name: chmod permissions
+                command: chmod +x ./gradlew
             - run: gradle build --parallel --console=plain
       - store_artifacts:
           path: ~/project/build/libs

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,7 +148,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradle build --parallel --build-cache --console=plain
+            - run: gradlew build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,7 +148,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: ./gradlew build --parallel --build-cache --console=plain
+            - run: gradle build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,7 +148,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradlew build --parallel --build-cache --console=plain
+            - run: ./gradlew build --parallel --build-cache --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -148,7 +148,7 @@ commands:
       - gradle/with_cache:
           cache_key: 'v9'
           steps:
-            - run: gradle build --parallel --build-cache --console=plain
+            - run: gradle build --parallel --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -151,7 +151,7 @@ commands:
             - run:
                 name: chmod permissions
                 command: chmod +x ./gradlew
-            - run: gradle build --parallel --console=plain
+            - run: ./gradlew build --parallel --console=plain
       - store_artifacts:
           path: ~/project/build/libs
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -146,7 +146,7 @@ commands:
     steps:
       - checkout
       - gradle/with_cache:
-          cache_key: 'v8'
+          cache_key: 'v9'
           steps:
             - run: gradle build --parallel --build-cache --console=plain
       - store_artifacts:

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'org.spongepowered.mixin' version '[0.7,0.8)'
     id 'org.parchmentmc.librarian.forgegradle' version '[1,2)'
     id 'org.moddingx.modgradle.mapping' version '[4,5)'
+    id 'org.moddingx.modgradle.sourcejar' version '[4,5)' apply false
     id 'io.github.0ffz.github-packages' version '[1,2)'
     id 'com.matthewprenger.cursegradle' version '[1.4,1.5)'
     id 'com.modrinth.minotaur' version '[2,3)'
@@ -22,8 +23,10 @@ base {
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
+apply plugin: 'org.moddingx.modgradle.sourcejar'
+
 minecraft {
-    mappings channel: 'parchment', version: project.mappings
+    mappings channel: 'sugarcane', version: project.mappings
 
     // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.
     // In most cases, it is not necessary to enable.

--- a/build.gradle
+++ b/build.gradle
@@ -1,68 +1,96 @@
+import net.minecraftforge.gradle.userdev.tasks.JarJar
+
 plugins {
+    id 'eclipse'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '5.1.+'
-    id 'org.spongepowered.mixin' version '0.7.+'
-    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
-    id 'org.moddingx.modgradle.sourcejar' version '3.+'
-    id 'io.github.0ffz.github-packages' version '1.+'
-    id 'com.matthewprenger.cursegradle' version '1.4.+'
-    id 'com.modrinth.minotaur' version '2.+'
+    id 'net.minecraftforge.gradle' version '[6.0,6.2)'
+    id 'org.spongepowered.mixin' version '[0.7,0.8)'
+    id 'org.parchmentmc.librarian.forgegradle' version '[1,2)'
+    id 'org.moddingx.modgradle.mapping' version '[4,5)'
+    id 'io.github.0ffz.github-packages' version '[1,2)'
+    id 'com.matthewprenger.cursegradle' version '[1.4,1.5)'
+    id 'com.modrinth.minotaur' version '[2,3)'
 }
 
-version = "${project.mc_version}-${project.mod_version}-forge"
+version = "${mc_version}-${mod_version}-forge"
 group = 'com.aetherteam.aether' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = project.mod_id
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(17) // Mojang ships Java 8 to end users, so your mod should target Java 8.
+base {
+    archivesName = mod_id
+}
+
+// Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 minecraft {
     mappings channel: 'parchment', version: project.mappings
 
+    // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.
+    // In most cases, it is not necessary to enable.
+    //enableEclipsePrepareRuns = true
+    //enableIdeaPrepareRuns = true
+
+    // This property allows configuring Gradle's ProcessResources task(s) to run on IDE output locations before launching the game.
+    // It is REQUIRED to be set to true for this template to function.
+    // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
+    copyIdeResources = true
+
+    // When true, this property will add the folder name of all declared run configurations to generated IDE run configurations.
+    // The folder name can be set on a run configuration using the "folderName" property.
+    // By default, the folder name of a run configuration is the name of the Gradle project containing it.
+    //generateRunFolders = true
+
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {
-        client {
+        // applies to all the run configs below
+        configureEach {
             workingDirectory project.file('run')
 
-            //Only uncomment this if you actually need the debug logging! If you enable this the log will be full of incredibly useless information spam
-            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-            //property 'forge.logging.console.level', 'debug'
+            // Applies a JVM property which can be referenced in your code to check if you are running in IDE/Gradle.
+            property "${mod_id}.iside", 'true'
+
+            // Recommended logging data for a userdev environment
+            // The markers can be added/remove as needed separated by commas.
+            // "SCAN": For mods scan.
+            // "REGISTRIES": For firing of registry events.
+            // "REGISTRYDUMP": For getting the contents of all registries.
+            //property 'forge.logging.markers', 'REGISTRIES'
+
+            // Recommended logging level for the console
+            // You can set various levels here.
+            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
+            property 'forge.logging.console.level', 'info' // info is the default for production
 
             mods {
-                "${project.mod_id}" {
+                "${mod_id}" {
                     source sourceSets.main
                 }
             }
+        }
+
+        client {
+            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
+            property 'forge.enabledGameTestNamespaces', mod_id
         }
 
         server {
-            workingDirectory project.file('run')
+            property 'forge.enabledGameTestNamespaces', mod_id
 
-            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-            //property 'forge.logging.console.level', 'debug'
+            args '--nogui'
+        }
 
-            mods {
-                "${project.mod_id}" {
-                    source sourceSets.main
-                }
-            }
+        // This run config launches GameTestServer and runs all registered gametests, then exits.
+        // By default, the server will crash when no gametests are provided.
+        // The gametest system is also enabled by default for other run configs under the /test command.
+        gameTestServer {
+            property 'forge.enabledGameTestNamespaces', mod_id
         }
 
         data {
-            workingDirectory project.file('run')
-
-            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-            //property 'forge.logging.console.level', 'debug'
-
-            args '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/'), '--existing', file('src/generated/resources/')
+            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/'), '--existing', file('src/generated/resources/')
 
             environment 'target', 'fmluserdevdata'
-
-            mods {
-                "${project.mod_id}" {
-                    source sourceSets.main
-                }
-            }
         }
     }
 }
@@ -117,7 +145,7 @@ repositories {
     maven githubPackage.invoke("The-Aether-Team/Nitrogen")
 }
 
-jar {
+tasks.named('jar', Jar).configure {
     manifest {
         attributes([
                 "Specification-Title"     : project.mod_name,
@@ -129,18 +157,17 @@ jar {
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
+
+    // This is the preferred method to reobfuscate your jar file
+    finalizedBy 'reobfJar'
+
+    archiveClassifier = 'no-embeds'
 }
 
-tasks.jar.configure {
-    archiveClassifier = "no-embeds"
+tasks.named('jarJar', JarJar).configure {
+    archiveClassifier = ''
 }
 
-tasks.jarJar.configure {
-    archiveClassifier = ""
-}
-
-// ensure jars are reobf'ed before confirming artifact files
-jar.finalizedBy('reobfJar')
 tasks.jarJar.finalizedBy('reobfJarJar')
 
 tasks.named(sourceSets.main.compileJavaTaskName) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ mod_name=The Aether
 mod_version=1.0.0-beta.5.1
 mc_version=1.19.4
 forge_version=45.1.0
-mappings=1.19.3-2023.03.12-1.19.4
+mappings=2023.06.26-1.19.4
 
 # Dependencies
 nitrogen_version=1.19.4-0.5.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,13 +7,6 @@ pluginManagement {
             if (plugin.startsWith('org.moddingx.modgradle.')) {
                 useModule "org.moddingx:ModGradle:${requested.version}"
             }
-
-            // everything else
-            switch (plugin) {
-                case 'org.spongepowered.mixin':
-                    useModule "org.spongepowered:mixingradle:${requested.version}"
-                    break
-            }
         }
     }
     repositories {
@@ -23,4 +16,8 @@ pluginManagement {
         maven { url = 'https://maven.parchmentmc.org' }
         maven { url = 'https://maven.moddingx.org' }
     }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
 }


### PR DESCRIPTION
I tried to get ModGradle's mapping plugin to work on ForgeGradle 5, but I kept getting weird build errors, so I decided to solve the problem by upgrading the entire buildscript anyway.

Buildscript upgrade details:
- Upgraded to Gradle 8.1.1.
- Gradle's Eclipse plugin has been updated and has returned to the buildscript.
- Upgraded to ForgeGradle 6.
- ForgeGradle 6 uses Gradle's foojar toolchain convention to work with java launchers. This is applied in `settings.gradle`.
- MixinGradle is now properly published as a modern Gradle plugin, and can be used in the plugin DSL without additional setup in `settings.gradle`.
- MixinGradle now no longer causes issues when the Eclipse plugin is applied.
- Archive base name is now set through the `base` closure block.
- ModGradle's SourceJar plugin needs to be applied manually after the Java language version is set (see ModdingX/ModGradle#17)
- ForgeGradle has introduced new options within the `minecraft` block. I have added them in with their default values.
- Run configurations can now have their base values properly configured for each.
- Added the `gameTestServer` run configuration (this has been here for a while but did not come included in ForgeGradle 4).
- Tasks can now be configured while casted to their proper type (ex. `Jar`, `JarJar`).

Sugarcane migration details:
- Sugarcane mappings are simply Parchment mappings but with sanitized parameter names (no more `p` prefix in parameter names).
- Sugarcane is automatically built for any Parchment release. The version schema is the same as Parchment's (see `gradle.properties`).