### PR TITLE
improv: Clean up existing Mixin config

### DIFF
--- a/src/main/java/com/aetherteam/aether/mixin/AetherMixinConfig.java
+++ b/src/main/java/com/aetherteam/aether/mixin/AetherMixinConfig.java
@@ -21,8 +21,6 @@ public class AetherMixinConfig {
 
     private static final ImmutableList<Entry> configEntries = ImmutableList.of(
             new Entry(MIXIN_PACKAGE_ROOT + "client.AdvancementToastMixin", true),
-            new Entry(MIXIN_PACKAGE_ROOT + "client.MinecraftMixin", true),
-            new Entry(MIXIN_PACKAGE_ROOT + "client.SplashManagerMixin", true),
             new Entry(MIXIN_PACKAGE_ROOT + "client.TippableArrowRendererMixin", true)
     );
 

--- a/src/main/java/com/aetherteam/aether/mixin/AetherMixinConfig.java
+++ b/src/main/java/com/aetherteam/aether/mixin/AetherMixinConfig.java
@@ -6,6 +6,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraftforge.fml.loading.FMLPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileReader;
@@ -15,11 +17,13 @@ import java.nio.file.Path;
 import java.util.Map;
 
 public class AetherMixinConfig {
-    private static final String MIXIN_PACKAGE_ROOT = "com.aetherteam.aether.core.mixin.";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AetherMixinConfig.class); // avoid calling LogUtils to avoid loading mojang/mc class early
+
+    private static final String MIXIN_PACKAGE_ROOT = "com.aetherteam.aether.mixin.mixins.";
     private static final Path DIRECTORY = FMLPaths.CONFIGDIR.get().resolve("aether");
     private static final File MIXIN_CONFIG = new File(DIRECTORY.toString(), "mixin_config.json");
 
-    private static final ImmutableList<Entry> configEntries = ImmutableList.of(
+    private static final ImmutableList<Entry> CONFIG_ENTRIES = ImmutableList.of(
             new Entry(MIXIN_PACKAGE_ROOT + "client.AdvancementToastMixin", true),
             new Entry(MIXIN_PACKAGE_ROOT + "client.TippableArrowRendererMixin", true)
     );
@@ -33,7 +37,7 @@ public class AetherMixinConfig {
                 Gson gson = new GsonBuilder().setPrettyPrinting().create();
                 JsonObject jsonObject = new JsonObject();
                 jsonObject.addProperty("comment", "Disabling these is not advised unless necessary");
-                for (Entry entry : configEntries) {
+                for (Entry entry : CONFIG_ENTRIES) {
                     jsonObject.addProperty(entry.path(), entry.defaultValue());
                 }
                 gson.toJson(jsonObject, fileWriter);
@@ -50,11 +54,17 @@ public class AetherMixinConfig {
                 JsonObject jsonObject = gson.fromJson(fileReader, JsonObject.class);
                 for (Map.Entry<String, JsonElement> property : jsonObject.entrySet()) {
                     if (property.getKey().equals(mixinClassName)) {
-                        return new Entry(property.getKey(), property.getValue().getAsBoolean());
+                        var entry = new Entry(property.getKey(), property.getValue().getAsBoolean());
+                        for (Entry configEntry : CONFIG_ENTRIES) {
+                            if (configEntry.path.equals(entry.path)) {
+                                return entry;
+                            }
+                        }
+                        LOGGER.error("Attempted to alter application of mixin {} from config, when it is not part of the config!", entry.path);
                     }
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.error("Failed to read mixin config!", e);
             }
         }
         return null;


### PR DESCRIPTION
Fixes #1594 for PR #1587.

I understand the sentiment of trying to clean up everything, but it's also important to recognize the current framework before tearing it down in favor of a new one. In this case, I've been looking through the `mixin` package to see if I can help with any cleanup of my own, and I've found the state of the mixin config to be **absolutely abysmal.**

This PR aims to solve a few things:
- It eliminates 2 of the original entries from the mixin config since those mixins no longer exist.
- It renames the base package of the mixin package for the config (since it got refactored and wasn't accounted for here).
- It improves the config loader so that only mixin classes that have been pre-defined in the `CONFIG_ENTRIES` variable can be loaded. If a user attempts to add an additional mixin into the config that didn't come with it, a single-line error will be printed to the console and it will simply be ignored.

Personally, I think this entire idea of making a config for disabling certain mixins is completely ridiculous and should be torn down whenever possible for the cleanup, but this PR accounts for a potential exploit to Aether's systems if kept.