### PR TITLE
refactor(event, entity): Made EggLayEvent use an ItemStack instead of an Item

### DIFF
--- a/src/main/java/com/aetherteam/aether/entity/passive/Moa.java
+++ b/src/main/java/com/aetherteam/aether/entity/passive/Moa.java
@@ -233,13 +233,13 @@ public class Moa extends MountableAnimal implements WingedBird {
 			if (!this.isBaby() && this.getPassengers().isEmpty() && --this.eggTime <= 0) {
 				MoaType moaType = this.getMoaType();
 				if (moaType != null) {
-					EggLayEvent eggLayEvent = AetherEventDispatch.onLayEgg(this, AetherSoundEvents.ENTITY_MOA_EGG.get(), 1.0F, (this.getRandom().nextFloat() - this.getRandom().nextFloat()) * 0.2F + 1.0F, this.getMoaType().getEgg());
+					EggLayEvent eggLayEvent = AetherEventDispatch.onLayEgg(this, AetherSoundEvents.ENTITY_MOA_EGG.get(), 1.0F, (this.getRandom().nextFloat() - this.getRandom().nextFloat()) * 0.2F + 1.0F, new ItemStack(this.getMoaType().getEgg()));
 					if (!eggLayEvent.isCanceled()) {
 						if (eggLayEvent.getSound() != null) {
 							this.playSound(eggLayEvent.getSound(), eggLayEvent.getVolume(), eggLayEvent.getPitch());
 						}
-						if (eggLayEvent.getItem() != null) {
-							this.spawnAtLocation(eggLayEvent.getItem());
+						if (eggLayEvent.getStack() != null) {
+							this.spawnAtLocation(eggLayEvent.getStack());
 						}
 					}
 				}

--- a/src/main/java/com/aetherteam/aether/event/AetherEventDispatch.java
+++ b/src/main/java/com/aetherteam/aether/event/AetherEventDispatch.java
@@ -20,8 +20,8 @@ public class AetherEventDispatch {
 	/**
 	 * @see EggLayEvent
 	 */
-	public static EggLayEvent onLayEgg(Entity entity, SoundEvent sound, float volume, float pitch, Item item) {
-		EggLayEvent event = new EggLayEvent(entity, sound, volume, pitch, item);
+	public static EggLayEvent onLayEgg(Entity entity, SoundEvent sound, float volume, float pitch, ItemStack stack) {
+		EggLayEvent event = new EggLayEvent(entity, sound, volume, pitch, stack);
 		MinecraftForge.EVENT_BUS.post(event);
 		return event;
 	}

--- a/src/main/java/com/aetherteam/aether/event/EggLayEvent.java
+++ b/src/main/java/com/aetherteam/aether/event/EggLayEvent.java
@@ -39,7 +39,7 @@ public class EggLayEvent extends EntityEvent {
      * @param sound The original {@link SoundEvent} played by laying the egg.
      * @param volume The original volume of the sound as a {@link Float}.
      * @param pitch The original pitch of the sound as a {@link Float}.
-     * @param item The original egg {@link Item} to be laid.
+     * @param stack The original egg {@link ItemStack} to be laid.
      */
     public EggLayEvent(Entity entity, @Nullable SoundEvent sound, float volume, float pitch, @Nullable ItemStack stack) {
         super(entity);
@@ -51,7 +51,7 @@ public class EggLayEvent extends EntityEvent {
 
     /**
      * This method is {@link Nullable}. If null, no egg item will be laid.
-     * @return The egg {@link Item} to be laid.
+     * @return The egg {@link ItemStack} to be laid.
      */
     @Nullable
     public ItemStack getStack() {
@@ -59,8 +59,8 @@ public class EggLayEvent extends EntityEvent {
     }
 
     /**
-     * Sets a new egg item to be laid.
-     * @param item The egg {@link Item}.
+     * Sets a new egg item stack to be laid.
+     * @param item The egg {@link ItemStack}.
      */
     public void setStack(@Nullable ItemStack stack) {
         this.stack = stack;

--- a/src/main/java/com/aetherteam/aether/event/EggLayEvent.java
+++ b/src/main/java/com/aetherteam/aether/event/EggLayEvent.java
@@ -3,6 +3,7 @@ package com.aetherteam.aether.event;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
@@ -27,7 +28,7 @@ import javax.annotation.Nullable;
 @Cancelable
 public class EggLayEvent extends EntityEvent {
     @Nullable
-    private Item item;
+    private ItemStack stack;
     @Nullable
     private SoundEvent sound;
     private float volume;
@@ -40,12 +41,12 @@ public class EggLayEvent extends EntityEvent {
      * @param pitch The original pitch of the sound as a {@link Float}.
      * @param item The original egg {@link Item} to be laid.
      */
-    public EggLayEvent(Entity entity, @Nullable SoundEvent sound, float volume, float pitch, @Nullable Item item) {
+    public EggLayEvent(Entity entity, @Nullable SoundEvent sound, float volume, float pitch, @Nullable ItemStack stack) {
         super(entity);
         this.sound = sound;
         this.volume = volume;
         this.pitch = pitch;
-        this.item = item;
+        this.stack = stack;
     }
 
     /**
@@ -53,16 +54,16 @@ public class EggLayEvent extends EntityEvent {
      * @return The egg {@link Item} to be laid.
      */
     @Nullable
-    public Item getItem() {
-        return this.item;
+    public ItemStack getStack() {
+        return this.stack;
     }
 
     /**
      * Sets a new egg item to be laid.
      * @param item The egg {@link Item}.
      */
-    public void setItem(@Nullable Item item) {
-        this.item = item;
+    public void setStack(@Nullable ItemStack stack) {
+        this.stack = stack;
     }
 
     /**


### PR DESCRIPTION
This pull request makes it so that the `EggLayEvent` stores an `ItemStack` instead of an `Item`, so that more information is given AND can be changed. For instance, I want to be able to store the `MoaType` in an NBT tag for the dropped item so that it can be used without needing to add a new item for each `MoaType` (which considering that other mods can add new `MoaTypes`, probably wouldn't be universally possible anyway)

---

I agree to the Contributor License Agreement (CLA).
