### PR TITLE
1.19.2 fix: missing categories in recipes

### DIFF
--- a/src/generated/resources/data/aether/recipes/bow_repairing.json
+++ b/src/generated/resources/data/aether/recipes/bow_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "ingredient": {
     "item": "minecraft:bow"
   },

--- a/src/generated/resources/data/aether/recipes/chainmail_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/chainmail_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:chainmail_boots"

--- a/src/generated/resources/data/aether/recipes/chainmail_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/chainmail_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:chainmail_chestplate"

--- a/src/generated/resources/data/aether/recipes/chainmail_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/chainmail_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:chainmail_gloves"

--- a/src/generated/resources/data/aether/recipes/chainmail_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/chainmail_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:chainmail_helmet"

--- a/src/generated/resources/data/aether/recipes/chainmail_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/chainmail_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:chainmail_leggings"

--- a/src/generated/resources/data/aether/recipes/diamond_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:diamond_axe"

--- a/src/generated/resources/data/aether/recipes/diamond_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:diamond_boots"

--- a/src/generated/resources/data/aether/recipes/diamond_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:diamond_chestplate"

--- a/src/generated/resources/data/aether/recipes/diamond_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:diamond_gloves"

--- a/src/generated/resources/data/aether/recipes/diamond_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:diamond_helmet"

--- a/src/generated/resources/data/aether/recipes/diamond_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:diamond_hoe"

--- a/src/generated/resources/data/aether/recipes/diamond_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:diamond_leggings"

--- a/src/generated/resources/data/aether/recipes/diamond_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:diamond_pickaxe"

--- a/src/generated/resources/data/aether/recipes/diamond_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:diamond_shovel"

--- a/src/generated/resources/data/aether/recipes/diamond_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/diamond_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:diamond_sword"

--- a/src/generated/resources/data/aether/recipes/fishing_rod_repairing.json
+++ b/src/generated/resources/data/aether/recipes/fishing_rod_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "ingredient": {
     "item": "minecraft:fishing_rod"
   },

--- a/src/generated/resources/data/aether/recipes/golden_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:golden_axe"

--- a/src/generated/resources/data/aether/recipes/golden_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:golden_boots"

--- a/src/generated/resources/data/aether/recipes/golden_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:golden_chestplate"

--- a/src/generated/resources/data/aether/recipes/golden_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:golden_gloves"

--- a/src/generated/resources/data/aether/recipes/golden_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:golden_helmet"

--- a/src/generated/resources/data/aether/recipes/golden_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:golden_hoe"

--- a/src/generated/resources/data/aether/recipes/golden_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:golden_leggings"

--- a/src/generated/resources/data/aether/recipes/golden_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:golden_pickaxe"

--- a/src/generated/resources/data/aether/recipes/golden_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:golden_shovel"

--- a/src/generated/resources/data/aether/recipes/golden_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/golden_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:golden_sword"

--- a/src/generated/resources/data/aether/recipes/gravitite_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "aether:gravitite_axe"

--- a/src/generated/resources/data/aether/recipes/gravitite_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "aether:gravitite_boots"

--- a/src/generated/resources/data/aether/recipes/gravitite_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "aether:gravitite_chestplate"

--- a/src/generated/resources/data/aether/recipes/gravitite_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:gravitite_gloves"

--- a/src/generated/resources/data/aether/recipes/gravitite_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "aether:gravitite_helmet"

--- a/src/generated/resources/data/aether/recipes/gravitite_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "aether:gravitite_hoe"

--- a/src/generated/resources/data/aether/recipes/gravitite_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "aether:gravitite_leggings"

--- a/src/generated/resources/data/aether/recipes/gravitite_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "aether:gravitite_pickaxe"

--- a/src/generated/resources/data/aether/recipes/gravitite_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "aether:gravitite_shovel"

--- a/src/generated/resources/data/aether/recipes/gravitite_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/gravitite_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "aether:gravitite_sword"

--- a/src/generated/resources/data/aether/recipes/holystone_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/holystone_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "aether:holystone_axe"

--- a/src/generated/resources/data/aether/recipes/holystone_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/holystone_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "aether:holystone_hoe"

--- a/src/generated/resources/data/aether/recipes/holystone_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/holystone_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "aether:holystone_pickaxe"

--- a/src/generated/resources/data/aether/recipes/holystone_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/holystone_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "aether:holystone_shovel"

--- a/src/generated/resources/data/aether/recipes/holystone_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/holystone_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "aether:holystone_sword"

--- a/src/generated/resources/data/aether/recipes/iron_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:iron_axe"

--- a/src/generated/resources/data/aether/recipes/iron_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:iron_boots"

--- a/src/generated/resources/data/aether/recipes/iron_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:iron_chestplate"

--- a/src/generated/resources/data/aether/recipes/iron_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:iron_gloves"

--- a/src/generated/resources/data/aether/recipes/iron_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:iron_helmet"

--- a/src/generated/resources/data/aether/recipes/iron_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:iron_hoe"

--- a/src/generated/resources/data/aether/recipes/iron_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:iron_leggings"

--- a/src/generated/resources/data/aether/recipes/iron_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:iron_pickaxe"

--- a/src/generated/resources/data/aether/recipes/iron_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:iron_shovel"

--- a/src/generated/resources/data/aether/recipes/iron_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/iron_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:iron_sword"

--- a/src/generated/resources/data/aether/recipes/leather_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/leather_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:leather_boots"

--- a/src/generated/resources/data/aether/recipes/leather_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/leather_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:leather_chestplate"

--- a/src/generated/resources/data/aether/recipes/leather_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/leather_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:leather_gloves"

--- a/src/generated/resources/data/aether/recipes/leather_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/leather_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:leather_helmet"

--- a/src/generated/resources/data/aether/recipes/leather_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/leather_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:leather_leggings"

--- a/src/generated/resources/data/aether/recipes/netherite_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:netherite_axe"

--- a/src/generated/resources/data/aether/recipes/netherite_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "minecraft:netherite_boots"

--- a/src/generated/resources/data/aether/recipes/netherite_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "minecraft:netherite_chestplate"

--- a/src/generated/resources/data/aether/recipes/netherite_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:netherite_gloves"

--- a/src/generated/resources/data/aether/recipes/netherite_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "minecraft:netherite_helmet"

--- a/src/generated/resources/data/aether/recipes/netherite_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:netherite_hoe"

--- a/src/generated/resources/data/aether/recipes/netherite_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "minecraft:netherite_leggings"

--- a/src/generated/resources/data/aether/recipes/netherite_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:netherite_pickaxe"

--- a/src/generated/resources/data/aether/recipes/netherite_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:netherite_shovel"

--- a/src/generated/resources/data/aether/recipes/netherite_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/netherite_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:netherite_sword"

--- a/src/generated/resources/data/aether/recipes/shield_repairing.json
+++ b/src/generated/resources/data/aether/recipes/shield_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "ingredient": {
     "item": "minecraft:shield"
   },

--- a/src/generated/resources/data/aether/recipes/skyroot_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/skyroot_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "aether:skyroot_axe"

--- a/src/generated/resources/data/aether/recipes/skyroot_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/skyroot_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "aether:skyroot_hoe"

--- a/src/generated/resources/data/aether/recipes/skyroot_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/skyroot_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "aether:skyroot_pickaxe"

--- a/src/generated/resources/data/aether/recipes/skyroot_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/skyroot_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "aether:skyroot_shovel"

--- a/src/generated/resources/data/aether/recipes/skyroot_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/skyroot_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "aether:skyroot_sword"

--- a/src/generated/resources/data/aether/recipes/stone_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/stone_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:stone_axe"

--- a/src/generated/resources/data/aether/recipes/stone_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/stone_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:stone_hoe"

--- a/src/generated/resources/data/aether/recipes/stone_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/stone_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:stone_pickaxe"

--- a/src/generated/resources/data/aether/recipes/stone_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/stone_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:stone_shovel"

--- a/src/generated/resources/data/aether/recipes/stone_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/stone_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:stone_sword"

--- a/src/generated/resources/data/aether/recipes/wooden_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/wooden_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "minecraft:wooden_axe"

--- a/src/generated/resources/data/aether/recipes/wooden_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/wooden_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "minecraft:wooden_hoe"

--- a/src/generated/resources/data/aether/recipes/wooden_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/wooden_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "minecraft:wooden_pickaxe"

--- a/src/generated/resources/data/aether/recipes/wooden_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/wooden_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "minecraft:wooden_shovel"

--- a/src/generated/resources/data/aether/recipes/wooden_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/wooden_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "minecraft:wooden_sword"

--- a/src/generated/resources/data/aether/recipes/zanite_axe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_axe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_axe_repair",
   "ingredient": {
     "item": "aether:zanite_axe"

--- a/src/generated/resources/data/aether/recipes/zanite_boots_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_boots_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_boots_repair",
   "ingredient": {
     "item": "aether:zanite_boots"

--- a/src/generated/resources/data/aether/recipes/zanite_chestplate_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_chestplate_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_chestplate_repair",
   "ingredient": {
     "item": "aether:zanite_chestplate"

--- a/src/generated/resources/data/aether/recipes/zanite_gloves_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_gloves_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_gloves_repair",
   "ingredient": {
     "item": "aether:zanite_gloves"

--- a/src/generated/resources/data/aether/recipes/zanite_helmet_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_helmet_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_helmet_repair",
   "ingredient": {
     "item": "aether:zanite_helmet"

--- a/src/generated/resources/data/aether/recipes/zanite_hoe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_hoe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_hoe_repair",
   "ingredient": {
     "item": "aether:zanite_hoe"

--- a/src/generated/resources/data/aether/recipes/zanite_leggings_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_leggings_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_leggings_repair",
   "ingredient": {
     "item": "aether:zanite_leggings"

--- a/src/generated/resources/data/aether/recipes/zanite_pendant_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_pendant_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pendant_repair",
   "ingredient": {
     "item": "aether:zanite_pendant"

--- a/src/generated/resources/data/aether/recipes/zanite_pickaxe_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_pickaxe_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_pickaxe_repair",
   "ingredient": {
     "item": "aether:zanite_pickaxe"

--- a/src/generated/resources/data/aether/recipes/zanite_ring_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_ring_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_ring_repair",
   "ingredient": {
     "item": "aether:zanite_ring"

--- a/src/generated/resources/data/aether/recipes/zanite_shovel_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_shovel_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_shovel_repair",
   "ingredient": {
     "item": "aether:zanite_shovel"

--- a/src/generated/resources/data/aether/recipes/zanite_sword_repairing.json
+++ b/src/generated/resources/data/aether/recipes/zanite_sword_repairing.json
@@ -1,5 +1,6 @@
 {
   "type": "aether:repairing",
+  "category": "enchanting_repair",
   "group": "altar_sword_repair",
   "ingredient": {
     "item": "aether:zanite_sword"


### PR DESCRIPTION
Players can't connect to Aether servers due to:
```
[Server thread/INFO] [net.minecraft.server.network.ServerGamePacketListenerImpl/]: [...] lost connection: Internal Exception: io.netty.handler.codec.EncoderException: java.lang.NullPointerException: Cannot invoke "java.lang.Enum.ordinal()" because "p_130069_" is null
```

---

I agree to the Contributor License Agreement (CLA).
