### PR TITLE
Update copper_lantern_conversion.json

### DIFF
--- a/src/main/resources/data/supplementaries/recipes/copper_lantern_conversion.json
+++ b/src/main/resources/data/supplementaries/recipes/copper_lantern_conversion.json
@@ -2,19 +2,19 @@
   "conditions": [
     {
       "type": "forge:mod_loaded",
-      "modid": "supplementaries"
+      "modid": "suppsquared"
     }
   ],
   "type": "aether:placement_conversion",
   "biome": "#aether:ultracold",
   "ingredient": {
-    "block": "supplementaries:copper_lantern",
+    "block": "suppsquared:copper_lantern",
     "properties": {
       "lit": "true"
     }
   },
   "result": {
-    "block": "supplementaries:copper_lantern",
+    "block": "suppsquared:copper_lantern",
     "properties": {
       "lit": "false"
     }


### PR DESCRIPTION
just noticed this while scrolling through this repo to see what the dimension ID is for mod compat. Anyways moved mod ids as the block itself was moved to supplementaries squared