### PR TITLE
fix: crash with OptiFine

### DIFF
--- a/src/main/java/com/aetherteam/aether/mixin/AetherMixinPlugin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/AetherMixinPlugin.java
@@ -1,0 +1,53 @@
+package com.aetherteam.aether.mixin;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class AetherMixinPlugin implements IMixinConfigPlugin {
+    private boolean isOptiFineInstalled = false;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        try {
+            Class.forName("optifine.Installer", false, getClass().getClassLoader());
+            isOptiFineInstalled = true;
+        } catch (ClassNotFoundException e) {
+        }
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (this.isOptiFineInstalled) {
+            if (mixinClassName.equals("com.aetherteam.aether.mixin.mixins.client.BossHealthOverlayMixin")) return false;
+            if (mixinClassName.equals("com.aetherteam.aether.mixin.mixins.client.optifine.BossHealthOverlayMixin")) return true;
+        }
+
+        return !mixinClassName.equals("com.aetherteam.aether.mixin.mixins.client.optifine.BossHealthOverlayMixin");
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/client/optifine/BossHealthOverlayMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/client/optifine/BossHealthOverlayMixin.java
@@ -1,0 +1,26 @@
+package com.aetherteam.aether.mixin.mixins.client.optifine;
+
+import com.aetherteam.aether.client.event.hooks.GuiHooks;
+import net.minecraft.client.gui.components.BossHealthOverlay;
+import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(BossHealthOverlay.class)
+public class BossHealthOverlayMixin {
+    /**
+     * Cancels the {@link CustomizeGuiOverlayEvent.BossEventProgress} GUI event after the event hook has been called for it.
+     * Made as a workaround for Jade's boss bar pushdown.<br>
+     * This modifies the assignment of the {@link CustomizeGuiOverlayEvent.BossEventProgress} event variable.
+     * @param event The original {@link CustomizeGuiOverlayEvent.BossEventProgress} parameter value.
+     * @return The modified {@link CustomizeGuiOverlayEvent.BossEventProgress} parameter value.
+     */
+    @ModifyVariable(at = @At(value = "STORE"), method = "render(Lnet/minecraft/client/gui/GuiGraphics;)V", index = 9)
+    @SuppressWarnings({"MixinAnnotationTarget", "InvalidInjectorMethodSignature"})
+    private Object event(Object event) {
+        CustomizeGuiOverlayEvent.BossEventProgress e = (CustomizeGuiOverlayEvent.BossEventProgress)event;
+        e.setCanceled(GuiHooks.BOSS_EVENTS.containsKey(e.getBossEvent().getId()));
+        return event;
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "com.aetherteam.aether.mixin.mixins",
+  "plugin": "com.aetherteam.aether.mixin.AetherMixinPlugin",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_17",
   "refmap": "aether.refmap.json",
@@ -65,7 +66,8 @@
     "client.accessor.PlayerModelAccessor",
     "client.accessor.QuadrupedModelAccessor",
     "client.accessor.ScreenAccessor",
-    "client.accessor.TitleScreenAccessor"
+    "client.accessor.TitleScreenAccessor",
+    "client.optifine.BossHealthOverlayMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
In the BossHealthOverlayMixin class, it calls to modify a variable that has `CustomizeGuiOverlayEvent.BossEventProgress`. In OptiFine, it uses it's own reflector classes to make it compatible with Forge. This is what is causing the crashes. What I have done is create two new classes, one is to apply the correct mixin based on if OptiFine is found. The other, is a fixed OptiFine mixin class.

The index has been changed to 9 instead of 7. And since in OptiFine the reflector method is an Object, it now calls for and returns an Object.

![image](https://github.com/The-Aether-Team/The-Aether/assets/60985521/e088df78-95f7-43c4-9af2-652abbd17af6)

I have tested with and without OptiFine, and it seems to work just fine.

---

I agree to the Contributor License Agreement (CLA).