### PR TITLE
Fix: Plunderer's Remourse Now Triggers On MC Soil

### DIFF
--- a/src/generated/resources/data/aether/advancements/valkyrie_hoe.json
+++ b/src/generated/resources/data/aether/advancements/valkyrie_hoe.json
@@ -12,7 +12,11 @@
                   "aether:aether_dirt",
                   "aether:aether_grass_block",
                   "aether:enchanted_aether_grass_block",
-                  "aether:aether_dirt_path"
+                  "aether:aether_dirt_path",
+                  "minecraft:dirt",
+                  "minecraft:rooted_dirt",
+                  "minecraft:coarse_dirt",
+                  "minecraft:dirt_path"
                 ]
               }
             }

--- a/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
@@ -42,6 +42,7 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -232,6 +233,10 @@ public class AbilityHooks {
                 .put(AetherBlocks.AETHER_GRASS_BLOCK.get(), AetherBlocks.AETHER_FARMLAND.get())
                 .put(AetherBlocks.ENCHANTED_AETHER_GRASS_BLOCK.get(), AetherBlocks.AETHER_FARMLAND.get())
                 .put(AetherBlocks.AETHER_DIRT_PATH.get(), AetherBlocks.AETHER_FARMLAND.get())
+                .put(Blocks.DIRT, Blocks.FARMLAND)
+                .put(Blocks.ROOTED_DIRT, Blocks.FARMLAND)
+                .put(Blocks.COARSE_DIRT, Blocks.FARMLAND)
+                .put(Blocks.DIRT_PATH, Blocks.FARMLAND)
                 .build();
 
         public static boolean debuffTools;


### PR DESCRIPTION
Plunderer's Remourse triggers only on tilling of aether soil, added MC vanilla blocks to relevant JSON and Immutable Hashmap.

I've tested this on my local, and is working as intended.

closes issue #1834 
---

I agree to the Contributor License Agreement (CLA).
