### PR TITLE
fix(gui): more fixes to silver heart rendering

### DIFF
--- a/src/generated/resources/data/aether/advancements/valkyrie_hoe.json
+++ b/src/generated/resources/data/aether/advancements/valkyrie_hoe.json
@@ -12,7 +12,11 @@
                   "aether:aether_dirt",
                   "aether:aether_grass_block",
                   "aether:enchanted_aether_grass_block",
-                  "aether:aether_dirt_path"
+                  "aether:aether_dirt_path",
+                  "minecraft:dirt",
+                  "minecraft:rooted_dirt",
+                  "minecraft:coarse_dirt",
+                  "minecraft:dirt_path"
                 ]
               }
             }

--- a/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
@@ -42,6 +42,7 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -232,6 +233,10 @@ public class AbilityHooks {
                 .put(AetherBlocks.AETHER_GRASS_BLOCK.get(), AetherBlocks.AETHER_FARMLAND.get())
                 .put(AetherBlocks.ENCHANTED_AETHER_GRASS_BLOCK.get(), AetherBlocks.AETHER_FARMLAND.get())
                 .put(AetherBlocks.AETHER_DIRT_PATH.get(), AetherBlocks.AETHER_FARMLAND.get())
+                .put(Blocks.DIRT, Blocks.FARMLAND)
+                .put(Blocks.ROOTED_DIRT, Blocks.FARMLAND)
+                .put(Blocks.COARSE_DIRT, Blocks.FARMLAND)
+                .put(Blocks.DIRT_PATH, Blocks.FARMLAND)
                 .build();
 
         public static boolean debuffTools;


### PR DESCRIPTION
Fixes a couple more issues regarding silver heart rendering. 
- Silver hearts will now properly shake if any are showing and your health is at or below 2 hearts.
  - Do note that if your max health goes into the negatives the shaking will still be incorrect. I can't do anything about this without rewriting the system.
- Silver hearts will no longer render too far to the left if your base max health is put in the negatives. This was very noticeable with [VoidScape's](https://www.curseforge.com/minecraft/mc-mods/voidscape) infusion effect in the void, which shrinks your max health the longer you're in the void. 

---

I agree to the Contributor License Agreement (CLA).