### PR TITLE
fix: MoaEggItem#byId will default with a Blue Moa Egg instead of null.

### DIFF
--- a/src/main/java/com/aetherteam/aether/item/miscellaneous/MoaEggItem.java
+++ b/src/main/java/com/aetherteam/aether/item/miscellaneous/MoaEggItem.java
@@ -3,6 +3,7 @@ package com.aetherteam.aether.item.miscellaneous;
 import com.aetherteam.aether.api.registers.MoaType;
 import com.aetherteam.aether.entity.AetherEntityTypes;
 import com.aetherteam.aether.entity.passive.Moa;
+import com.aetherteam.aether.item.AetherItems;
 import com.aetherteam.aether.mixin.mixins.common.accessor.BaseSpawnerAccessor;
 import com.google.common.collect.Iterables;
 import net.minecraft.core.BlockPos;
@@ -193,7 +194,7 @@ public class MoaEggItem extends Item {
                 return BY_ID.get(holder);
             }
         }
-        return null;
+        return (MoaEggItem) AetherItems.BLUE_MOA_EGG.get();
     }
 
     /**


### PR DESCRIPTION
#1897 