### PR TITLE
Fix generic Curios icons being used rather than the charm/ring ones

### DIFF
--- a/src/main/resources/packs/curios_override/data/curios/curios/slots/charm.json
+++ b/src/main/resources/packs/curios_override/data/curios/curios/slots/charm.json
@@ -1,3 +1,4 @@
 {
-  "size": 2
+  "size": 2,
+  "icon": "curios:slot/empty_charm_slot"
 }

--- a/src/main/resources/packs/curios_override/data/curios/curios/slots/ring.json
+++ b/src/main/resources/packs/curios_override/data/curios/curios/slots/ring.json
@@ -1,3 +1,4 @@
 {
-  "size": 2
+  "size": 2,
+  "icon": "curios:slot/empty_ring_slot"
 }


### PR DESCRIPTION
Hey guys! I noticed a minor quirk in the `Use default Curios' menu config` option. The slots registered in the datapack do not specify what icons they use, so they default to the generic curios icons which makes rings and charms indistinguishable.

![bad](https://github.com/The-Aether-Team/The-Aether/assets/32613991/b2e92080-aca0-4f7b-8263-a591799cb86e)

Curious has icons for ring/charm slots built-in, so it would be a shame not to use them! Here is how it'll look with this datapack change:

![good](https://github.com/The-Aether-Team/The-Aether/assets/32613991/c85145c9-ee63-4437-9b0d-4ede07d0ba16)
