### PR TITLE
Optimize block recipe checking to reduce overhead on block updates

### DIFF
--- a/src/main/java/com/aetherteam/aether/event/listeners/RecipeListener.java
+++ b/src/main/java/com/aetherteam/aether/event/listeners/RecipeListener.java
@@ -45,9 +45,10 @@ public class RecipeListener {
     @SubscribeEvent
     public static void onNeighborNotified(BlockEvent.NeighborNotifyEvent event) {
         LevelAccessor levelAccessor = event.getLevel();
-        if (!levelAccessor.dimensionType().effectsLocation().equals(AetherDimensions.AETHER_DIMENSION_TYPE.location()) return;
         BlockPos blockPos = event.getPos();
-        RecipeHooks.checkExistenceBanned(levelAccessor, blockPos);
+        if (levelAccessor.dimensionType().effectsLocation().equals(AetherDimensions.AETHER_DIMENSION_TYPE.location()) {
+            RecipeHooks.checkExistenceBanned(levelAccessor, blockPos);
+        }
         RecipeHooks.sendIcestoneFreezableUpdateEvent(levelAccessor, blockPos);
     }
 

--- a/src/main/java/com/aetherteam/aether/event/listeners/RecipeListener.java
+++ b/src/main/java/com/aetherteam/aether/event/listeners/RecipeListener.java
@@ -45,6 +45,7 @@ public class RecipeListener {
     @SubscribeEvent
     public static void onNeighborNotified(BlockEvent.NeighborNotifyEvent event) {
         LevelAccessor levelAccessor = event.getLevel();
+        if (!levelAccessor.dimensionType().effectsLocation().equals(AetherDimensions.AETHER_DIMENSION_TYPE.location()) return;
         BlockPos blockPos = event.getPos();
         RecipeHooks.checkExistenceBanned(levelAccessor, blockPos);
         RecipeHooks.sendIcestoneFreezableUpdateEvent(levelAccessor, blockPos);


### PR DESCRIPTION
closes issue #1949
This would make the **block recipes no longer work in dimensions other than the aether**, check the issue for more details.
I agree to the Contributor License Agreement (CLA).
