### PR TITLE
fix: [Aerclouds] Removing "setOnGround" in entityInside method fixes undefined jumping behaviour

### DIFF
--- a/src/main/java/com/aetherteam/aether/block/natural/BlueAercloudBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/natural/BlueAercloudBlock.java
@@ -3,7 +3,6 @@ package com.aetherteam.aether.block.natural;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.BlockGetter;
@@ -46,11 +45,11 @@ public class BlueAercloudBlock extends AercloudBlock {
 					level.addParticle(ParticleTypes.SPLASH, xOffset, yOffset, zOffset, 0.0, 0.0, 0.0);
 				}
 			}
-			if (entity instanceof LivingEntity livingEntity && (!livingEntity.isFallFlying() && (!(entity instanceof Player player) || !player.getAbilities().flying))) {
-				entity.setOnGround(true);
-			} else if (!(entity instanceof Projectile)) {
+
+			if (!(entity instanceof Projectile)) {
 				entity.setOnGround(false);
 			}
+
 		} else {
 			super.entityInside(state, level, pos, entity);
 		}


### PR DESCRIPTION
setOnGround is called the moment entityInside detects the player is inside the block, However, this causes undefined behaviour when the player jumps the moment they are inside the block, this is wrong as the player can basically jump on top of the block. This is unintentional and gets worse with the blue aether clouds where you can jump without triggering it's up effect.

With setOnGround:

https://github.com/The-Aether-Team/The-Aether/assets/55441008/36daf0b3-9f78-4963-88b6-1131c819999c


Without setOnGround:

https://github.com/The-Aether-Team/The-Aether/assets/55441008/fa2ccc69-6fcb-423e-9a8c-55b40eb5f213


The player regains the ability to jump once they've hit the bottom of the aercloud, which is inline with the original Aether. 