### PR TITLE
fix(mod-compatibility): Add compat for Combatify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ dependencies {
 
 //    compileOnly fileTree(dir: 'libs', include: '*.jar')
 
-    runtimeOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:$rei_version")
+//    runtimeOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:$rei_version")
 
     compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-api-forge:$rei_version")
     compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-default-plugin-forge:$rei_version")

--- a/build.gradle
+++ b/build.gradle
@@ -111,16 +111,12 @@ dependencies {
         jarJar.pin(it, "${project.curios_version}+${project.mc_version}")
     }
 
-    /*compileOnly "mezz.jei:jei-${project.mc_version}-common:${project.jei_version}"
-    compileOnly "mezz.jei:jei-${project.mc_version}-forge:${project.jei_version}"*/
-
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-common-api:${project.jei_version}"))
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${project.jei_version}"))
 
     runtimeOnly compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${project.jei_version}"))
 
     compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-${project.crafttweaker_version}")
-//    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-${project.crafttweaker_version}")
 
 //    runtimeOnly fg.deobf("net.darkhax.bookshelf:Bookshelf-Forge-1.20.1:20.0.5")
 //    runtimeOnly fg.deobf("net.darkhax.tips:Tips-Forge-1.20.1:12.0.3")

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,6 @@ lootr_version=4608503
 #colytra_version=3310142
 #https://www.curseforge.com/minecraft/mc-mods/curious-elytra/files/3601975
 #curiouselytra_version=3601975
-
 rei_version=12.0.684
 cloth_config_version=11.1.118
 architectury_version=9.1.12

--- a/src/main/java/com/aetherteam/aether/integration/rei/AetherREIClientPlugin.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/AetherREIClientPlugin.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 @REIPluginClient
 public class AetherREIClientPlugin implements REIClientPlugin {
-
     public static final ResourceLocation ALTAR_TEXTURE = new ResourceLocation(Aether.MODID, "textures/gui/menu/altar.png");
 
     @Override

--- a/src/main/java/com/aetherteam/aether/integration/rei/AetherREIServerPlugin.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/AetherREIServerPlugin.java
@@ -21,7 +21,6 @@ import net.minecraft.resources.ResourceLocation;
 
 @REIPluginCommon
 public class AetherREIServerPlugin implements REIServerPlugin {
-
     public static final CategoryIdentifier<PlacementBanRecipeDisplay<BlockBanRecipe>> BLOCK_PLACEMENT_BAN = CategoryIdentifier.of(new ResourceLocation(Aether.MODID, "block_placement_ban"));
     public static final CategoryIdentifier<PlacementBanRecipeDisplay<ItemBanRecipe>> ITEM_PLACEMENT_BAN = CategoryIdentifier.of(new ResourceLocation(Aether.MODID, "item_placement_ban"));
 

--- a/src/main/java/com/aetherteam/aether/integration/rei/AetherREIServerPlugin.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/AetherREIServerPlugin.java
@@ -14,7 +14,6 @@ import com.aetherteam.nitrogen.integration.rei.displays.BlockStateRecipeDisplay;
 import com.aetherteam.nitrogen.integration.rei.displays.FuelDisplay;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
-import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
 import me.shedaniel.rei.api.common.plugins.REIServerPlugin;
 import me.shedaniel.rei.forge.REIPluginCommon;
 import net.minecraft.resources.ResourceLocation;
@@ -44,7 +43,5 @@ public class AetherREIServerPlugin implements REIServerPlugin {
         registry.register(ALTAR_ENCHANTING, AetherCookingRecipeDisplay.serializer(ALTAR_ENCHANTING));
         registry.register(FREEZING, AetherCookingRecipeDisplay.serializer(FREEZING));
         registry.register(INCUBATING, AetherCookingRecipeDisplay.serializer(INCUBATING));
-
-        // TODO: Add other displays serializers
     }
 }

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/BiomeTooltip.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/BiomeTooltip.java
@@ -13,18 +13,18 @@ import javax.annotation.Nullable;
 
 public interface BiomeTooltip {
     default void populateBiomeInformation(@Nullable ResourceKey<Biome> biomeKey, @Nullable TagKey<Biome> biomeTag, Tooltip tooltip) {
-        if (Minecraft.getInstance().level == null || (biomeKey == null && biomeTag == null)) return;
+        if (Minecraft.getInstance().level != null && (biomeKey != null || biomeTag != null)) {
+            tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip").withStyle(ChatFormatting.GRAY));
+            if (biomeKey != null) {
+                tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.biome").withStyle(ChatFormatting.DARK_GRAY));
+                tooltip.add(Component.literal(biomeKey.location().toString()).withStyle(ChatFormatting.DARK_GRAY));
+            } else {
+                tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.tag").withStyle(ChatFormatting.DARK_GRAY));
+                tooltip.add(Component.literal("#" + biomeTag.location()).withStyle(ChatFormatting.DARK_GRAY));
 
-        tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip").withStyle(ChatFormatting.GRAY));
-        if (biomeKey != null) {
-            tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.biome").withStyle(ChatFormatting.DARK_GRAY));
-            tooltip.add(Component.literal(biomeKey.location().toString()).withStyle(ChatFormatting.DARK_GRAY));
-        } else {
-            tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.tag").withStyle(ChatFormatting.DARK_GRAY));
-            tooltip.add(Component.literal("#" + biomeTag.location()).withStyle(ChatFormatting.DARK_GRAY));
-
-            tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.biomes").withStyle(ChatFormatting.DARK_GRAY));
-            Minecraft.getInstance().level.registryAccess().registryOrThrow(Registries.BIOME).getTagOrEmpty(biomeTag).forEach((biomeHolder) -> biomeHolder.unwrapKey().ifPresent((key) -> tooltip.add(Component.literal(key.location().toString()).withStyle(ChatFormatting.DARK_GRAY))));
+                tooltip.add(Component.translatable("gui.aether.jei.biome.tooltip.biomes").withStyle(ChatFormatting.DARK_GRAY));
+                Minecraft.getInstance().level.registryAccess().registryOrThrow(Registries.BIOME).getTagOrEmpty(biomeTag).forEach((biomeHolder) -> biomeHolder.unwrapKey().ifPresent((key) -> tooltip.add(Component.literal(key.location().toString()).withStyle(ChatFormatting.DARK_GRAY))));
+            }
         }
     }
 }

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/AbstractPlacementBanRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/AbstractPlacementBanRecipeCategory.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public abstract class AbstractPlacementBanRecipeCategory<T, S extends Predicate<T>, R extends AbstractPlacementBanRecipe<T, S>> extends AbstractRecipeCategory<PlacementBanRecipeDisplay<R>> implements BiomeTooltip {
-
     public AbstractPlacementBanRecipeCategory(String id, CategoryIdentifier<PlacementBanRecipeDisplay<R>> uid, Renderer icon) {
         super(id, uid, 116, 18, icon);
     }
@@ -61,8 +60,8 @@ public abstract class AbstractPlacementBanRecipeCategory<T, S extends Predicate<
     }
 
     protected void populateTooltip(PlacementBanRecipeDisplay<R> display, Tooltip tooltip) {
-        if (Minecraft.getInstance().level == null) return;
-
-        this.populateBiomeInformation(display.getBiomeKey(), display.getBiomeTag(), tooltip);
+        if (Minecraft.getInstance().level != null) {
+            this.populateBiomeInformation(display.getBiomeKey(), display.getBiomeTag(), tooltip);
+        }
     }
 }

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/BlockBanRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/BlockBanRecipeCategory.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import java.util.List;
 
 public class BlockBanRecipeCategory extends AbstractPlacementBanRecipeCategory<BlockState, BlockStateIngredient, BlockBanRecipe> {
-
     public BlockBanRecipeCategory() {
         super("block_placement_ban", AetherREIServerPlugin.BLOCK_PLACEMENT_BAN, EntryStack.of(VanillaEntryTypes.ITEM, new ItemStack(Blocks.TORCH)));
     }
@@ -28,7 +27,7 @@ public class BlockBanRecipeCategory extends AbstractPlacementBanRecipeCategory<B
 
         Point startingPoint;
 
-        if(display.getBypassBlock() == null || display.getBypassBlock().isEmpty()){
+        if (display.getBypassBlock() == null || display.getBypassBlock().isEmpty()) {
             startingPoint = new Point(bounds.getCenterX() - 8, bounds.getCenterY() - 8);
         } else {
             startingPoint = startingOffset(bounds);

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/ItemBanRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/ItemBanRecipeCategory.java
@@ -16,7 +16,6 @@ import net.minecraft.world.item.crafting.Ingredient;
 import java.util.List;
 
 public class ItemBanRecipeCategory extends AbstractPlacementBanRecipeCategory<ItemStack, Ingredient, ItemBanRecipe> {
-
     public ItemBanRecipeCategory() {
         super("item_placement_ban", AetherREIServerPlugin.ITEM_PLACEMENT_BAN, EntryStack.of(VanillaEntryTypes.ITEM, new ItemStack(Items.FLINT_AND_STEEL)));
     }
@@ -27,7 +26,7 @@ public class ItemBanRecipeCategory extends AbstractPlacementBanRecipeCategory<It
 
         Point startingPoint;
 
-        if(display.getBypassBlock() == null || display.getBypassBlock().isEmpty()){
+        if (display.getBypassBlock() == null || display.getBypassBlock().isEmpty()) {
             startingPoint = new Point(bounds.getCenterX() - 8, bounds.getCenterY() - 8);
         } else {
             startingPoint = startingOffset(bounds);

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/PlacementBanRecipeDisplay.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/ban/PlacementBanRecipeDisplay.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 // TODO: Implement DisplaySerializer within the future
 public class PlacementBanRecipeDisplay<R extends AbstractPlacementBanRecipe<?, ?>> extends BasicDisplay {
-
     private final CategoryIdentifier<?> categoryIdentifier;
 
     private final BlockStateIngredient bypassBlock;
@@ -83,11 +82,11 @@ public class PlacementBanRecipeDisplay<R extends AbstractPlacementBanRecipe<?, ?
 
     @Nullable
     public BlockStateIngredient getBlockStateIngredient() {
-        return blockStateIngredient.orElse(null);
+        return this.blockStateIngredient.orElse(null);
     }
 
     @Override
     public CategoryIdentifier<?> getCategoryIdentifier() {
-        return categoryIdentifier;
+        return this.categoryIdentifier;
     }
 }

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/block/AetherBlockStateRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/block/AetherBlockStateRecipeCategory.java
@@ -15,7 +15,6 @@ import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.network.chat.Component;
 
 public class AetherBlockStateRecipeCategory<R extends AbstractBlockStateRecipe> extends AbstractBlockStateRecipeCategory<R> {
-
     protected AetherBlockStateRecipeCategory(String id, CategoryIdentifier<BlockStateRecipeDisplay<R>> uid, int width, int height, Renderer icon) {
         super(id, uid, width, height, icon);
     }
@@ -24,8 +23,6 @@ public class AetherBlockStateRecipeCategory<R extends AbstractBlockStateRecipe> 
     public Component getTitle() {
         return Component.translatable("gui.aether.jei." + this.id);
     }
-
-    //--
 
     public static AetherBlockStateRecipeCategory<AccessoryFreezableRecipe> accessoryFreezable() {
         return new AetherBlockStateRecipeCategory<>("accessory_freezable", AetherREIServerPlugin.ACCESSORY_FREEZABLE,84, 28, EntryStacks.of(AetherItems.ICE_RING.get()));

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/block/BiomeParameterRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/block/BiomeParameterRecipeCategory.java
@@ -13,7 +13,6 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 
 public class BiomeParameterRecipeCategory<R extends AbstractBiomeParameterRecipe> extends AetherBlockStateRecipeCategory<R> implements BiomeTooltip {
-
     protected BiomeParameterRecipeCategory(String id, CategoryIdentifier<BlockStateRecipeDisplay<R>> uid, int width, int height, Renderer icon) {
         super(id, uid, width, height, icon);
     }
@@ -22,8 +21,6 @@ public class BiomeParameterRecipeCategory<R extends AbstractBiomeParameterRecipe
     protected void populateTooltip(BlockStateRecipeDisplay<R> display, Tooltip tooltip) {
         this.populateBiomeInformation(display.getRecipe().getBiomeKey(), display.getRecipe().getBiomeTag(), tooltip);
     }
-
-    //--
 
     public static BiomeParameterRecipeCategory<PlacementConversionRecipe> placementConversion() {
         return new BiomeParameterRecipeCategory<>("placement_conversion", AetherREIServerPlugin.PLACEMENT_CONVERSION, 84, 28, EntryStacks.of(AetherItems.AETHER_PORTAL_FRAME.get()));

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeCategory.java
@@ -20,7 +20,6 @@ import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.crafting.AbstractCookingRecipe;
 import net.minecraft.world.item.crafting.Recipe;
 import org.apache.commons.lang3.mutable.MutableDouble;
 
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRecipeCategory<AetherCookingRecipeDisplay<R>> {
-
     public static final ResourceLocation ALTAR_TEXTURE = new ResourceLocation(Aether.MODID, "textures/gui/menu/altar.png");
     public static final ResourceLocation FREEZER_TEXTURE = new ResourceLocation(Aether.MODID, "textures/gui/menu/freezer.png");
     public static final ResourceLocation INCUBATOR_TEXTURE = new ResourceLocation(Aether.MODID, "textures/gui/menu/incubator.png");
@@ -48,23 +46,23 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
         this.animatedProgressArrow = animatedProgressArrow;
     }
 
-    public static AetherCookingRecipeCategory<AltarRepairRecipe> altarRepair(){
+    public static AetherCookingRecipeCategory<AltarRepairRecipe> altarRepair() {
         return new AetherCookingRecipeCategory<>("altar.repairing", AetherREIServerPlugin.ALTAR_REPAIR, 140, 39, EntryStacks.of(AetherBlocks.ALTAR.get()), ALTAR_TEXTURE);
     }
 
-    public static AetherCookingRecipeCategory<EnchantingRecipe> altarEnchanting(){
+    public static AetherCookingRecipeCategory<EnchantingRecipe> altarEnchanting() {
         return new AetherCookingRecipeCategory<>("altar.enchanting", AetherREIServerPlugin.ALTAR_ENCHANTING, 140, 39, EntryStacks.of(AetherBlocks.ALTAR.get()), ALTAR_TEXTURE);
     }
 
-    public static AetherCookingRecipeCategory<FreezingRecipe> freezing(){
+    public static AetherCookingRecipeCategory<FreezingRecipe> freezing() {
         return new AetherCookingRecipeCategory<>("freezing", AetherREIServerPlugin.FREEZING, 140, 39, EntryStacks.of(AetherBlocks.FREEZER.get()), FREEZER_TEXTURE);
     }
 
-    public static AetherCookingRecipeCategory<IncubationRecipe> incubating(){
+    public static AetherCookingRecipeCategory<IncubationRecipe> incubating() {
         return new AetherCookingRecipeCategory<>("incubating", AetherREIServerPlugin.INCUBATING, 88, 54, EntryStacks.of(AetherBlocks.INCUBATOR.get()), INCUBATOR_TEXTURE, () -> {
             var lastTick = new MutableDouble(0);
 
-            var widgetBound = new Rectangle(8, -13, 10, 54); //new Rectangle(14, 3, 54, 10);
+            var widgetBound = new Rectangle(8, -13, 10, 54);
 
             return Widgets.wrapRenderer(widgetBound, (graphics, bound, mouseX, mouseY, delta) -> {
                 lastTick.getAndAdd(delta);
@@ -74,11 +72,6 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
                 var textureLength = 54;
                 var scissorOffset = (int) Math.round(textureLength * (lastTick.getValue() / 5700));
 
-//                graphics.blit(INCUBATOR_TEXTURE, bound.x, bound.y, 192, 0, 54, 9);
-//                graphics.enableScissor(bound.x - scissorOffset, bound.y, bound.x + textureLength - scissorOffset, bound.y + 10);
-//                graphics.blit(INCUBATOR_TEXTURE, bound.x, bound.y, 192, 9, 54, 10);
-//                graphics.disableScissor();
-
                 graphics.blit(INCUBATOR_TEXTURE, bound.x, bound.y, 103, 16, 9, 54);
                 graphics.enableScissor(bound.x, bound.y + textureLength - scissorOffset, bound.x + 10, bound.y + (textureLength * 2) - scissorOffset);
                 graphics.blit(INCUBATOR_TEXTURE, bound.x, bound.y, 179, 16, 10, 54);
@@ -87,19 +80,19 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
         });
     }
 
-    private static WidgetWithBounds fuelIndicator(ResourceLocation texture){
-        return Widgets.wrapRenderer(new Rectangle(14, 13), (graphics, bounds, mouseX, mouseY, delta) -> {
-            graphics.blit(texture, bounds.x, bounds.y, 176, 0, 14, 13);
-        });
+    private static WidgetWithBounds fuelIndicator(ResourceLocation texture) {
+        return Widgets.wrapRenderer(new Rectangle(14, 13), (graphics, bounds, mouseX, mouseY, delta) -> graphics.blit(texture, bounds.x, bounds.y, 176, 0, 14, 13));
     }
 
-    private static WidgetWithBounds animatedArrow(ResourceLocation texture, int burnTime){
+    private static WidgetWithBounds animatedArrow(ResourceLocation texture, int burnTime) {
         var lastTick = new MutableDouble(0);
 
         return Widgets.wrapRenderer(new Rectangle(23, 16), (graphics, bound, mouseX, mouseY, delta) -> {
             lastTick.getAndAdd(delta);
 
-            if(lastTick.getValue() > burnTime) lastTick.setValue(0);
+            if (lastTick.getValue() > burnTime) {
+                lastTick.setValue(0);
+            }
 
             var xOffset = 23 - (int) Math.round(23 * (lastTick.getValue() / burnTime));
 
@@ -123,7 +116,7 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
         int cookingTime = display.getCookingTime();
 
         Component cookInfo;
-        if(experience > 0){
+        if (experience > 0) {
             cookInfo = Component.translatable("category.rei.cooking.time&xp", df.format(experience), df.format(cookingTime / 20d));
         } else {
             cookInfo = Component.translatable("category.rei.campfire.time", df.format(cookingTime / 20d));
@@ -141,7 +134,9 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
         arrowWidget.getBounds().translate(arrowPoint.x, arrowPoint.y);
         widgets.add(arrowWidget);
 
-        if(display.isIncubation()) startPoint.translate(6, 5);
+        if (display.isIncubation()) {
+            startPoint.translate(6, 5);
+        }
 
         var fuelWidget = this.fuelIndicator.get();
         fuelWidget.getBounds().move(startPoint.x + 2, startPoint.y + 20);
@@ -153,7 +148,7 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
 
         var outputEntries = display.getOutputEntries();
 
-        if(outputEntries.size() > 0) {
+        if (outputEntries.size() > 0) {
             widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 61, startPoint.y + 9)));
 
             widgets.add(Widgets.createSlot(new Point(startPoint.x + 61, startPoint.y + 9))

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeCategory.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeCategory.java
@@ -124,7 +124,9 @@ public class AetherCookingRecipeCategory<R extends Recipe<?>> extends AbstractRe
 
         var labelPoint = new Point(bounds.x + bounds.width - 5, bounds.y + 5);
 
-        if(display.isIncubation()) labelPoint.move(labelPoint.x, bounds.getCenterY() - Minecraft.getInstance().font.lineHeight / 2);
+        if (display.isIncubation()) {
+            labelPoint.move(labelPoint.x, bounds.getCenterY() - Minecraft.getInstance().font.lineHeight / 2);
+        }
 
         widgets.add(Widgets.createLabel(labelPoint, cookInfo).noShadow().rightAligned().color(0xFF404040, 0xFFBBBBBB));
 

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeDisplay.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeDisplay.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 
 public class AetherCookingRecipeDisplay<T extends Recipe<?>> extends BasicDisplay {
-
     private final CategoryIdentifier<?> identifier;
 
     private final float experience;
@@ -39,39 +38,41 @@ public class AetherCookingRecipeDisplay<T extends Recipe<?>> extends BasicDispla
         var cookingTime = 0;
         var experience = 0f;
 
-        if(recipe instanceof AbstractCookingRecipe cookingRecipe){
+        if (recipe instanceof AbstractCookingRecipe cookingRecipe){
             cookingTime = cookingRecipe.getCookingTime();
             experience = cookingRecipe.getExperience();
-        } else if(recipe instanceof IncubationRecipe incubationRecipe){
+        } else if (recipe instanceof IncubationRecipe incubationRecipe){
             cookingTime = incubationRecipe.getIncubationTime();
         }
 
         return new AetherCookingRecipeDisplay<>(categoryIdentifier, getInput(recipe), getOutput(recipe), experience, cookingTime, (recipe instanceof IncubationRecipe), Optional.of(recipe.getId()));
     }
 
-    private static List<EntryIngredient> getInput(Recipe<?> recipe){
-        if(!(recipe instanceof AltarRepairRecipe)) return List.of(EntryIngredients.ofIngredient(recipe.getIngredients().get(0)));
+    private static List<EntryIngredient> getInput(Recipe<?> recipe) {
+        if (recipe instanceof AltarRepairRecipe) {
+            ItemStack damagedItem = recipe.getIngredients().get(0).getItems()[0].copy();
+            damagedItem.setDamageValue(damagedItem.getMaxDamage() * 3 / 4);
 
-        ItemStack damagedItem = recipe.getIngredients().get(0).getItems()[0].copy();
-        damagedItem.setDamageValue(damagedItem.getMaxDamage() * 3 / 4);
-
-        return List.of(EntryIngredients.of(damagedItem));
+            return List.of(EntryIngredients.of(damagedItem));
+        } else {
+            return List.of(EntryIngredients.ofIngredient(recipe.getIngredients().get(0)));
+        }
     }
 
-    private static List<EntryIngredient> getOutput(Recipe<?> recipe){
+    private static List<EntryIngredient> getOutput(Recipe<?> recipe) {
         return (recipe instanceof AbstractAetherCookingRecipe cookingRecipe) ? List.of(EntryIngredients.of(cookingRecipe.getResult())) : List.of();
     }
 
     public float getExperience() {
-        return experience;
+        return this.experience;
     }
 
     public int getCookingTime() {
-        return cookingTime;
+        return this.cookingTime;
     }
 
-    public boolean isIncubation(){
-        return isIncubation;
+    public boolean isIncubation() {
+        return this.isIncubation;
     }
 
     @Override
@@ -79,7 +80,7 @@ public class AetherCookingRecipeDisplay<T extends Recipe<?>> extends BasicDispla
         return this.identifier;
     }
 
-    public static <T extends Recipe<?>> DisplaySerializer<AetherCookingRecipeDisplay<T>> serializer(CategoryIdentifier<AetherCookingRecipeDisplay<T>> identifier){
+    public static <T extends Recipe<?>> DisplaySerializer<AetherCookingRecipeDisplay<T>> serializer(CategoryIdentifier<AetherCookingRecipeDisplay<T>> identifier) {
         return BasicDisplay.Serializer.of((input, output, location1, tag) -> {
             var experience = tag.getFloat("experience");
             var cookingTime = tag.getInt("cookingTime");

--- a/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeDisplay.java
+++ b/src/main/java/com/aetherteam/aether/integration/rei/categories/item/AetherCookingRecipeDisplay.java
@@ -1,6 +1,5 @@
 package com.aetherteam.aether.integration.rei.categories.item;
 
-import com.aetherteam.aether.integration.rei.AetherREIServerPlugin;
 import com.aetherteam.aether.recipe.recipes.item.AbstractAetherCookingRecipe;
 import com.aetherteam.aether.recipe.recipes.item.AltarRepairRecipe;
 import com.aetherteam.aether.recipe.recipes.item.IncubationRecipe;
@@ -9,7 +8,6 @@ import me.shedaniel.rei.api.common.display.DisplaySerializer;
 import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.AbstractCookingRecipe;

--- a/src/main/java/com/aetherteam/aether/item/EquipmentUtil.java
+++ b/src/main/java/com/aetherteam/aether/item/EquipmentUtil.java
@@ -25,7 +25,7 @@ public final class EquipmentUtil {
      * @return Whether the attack was full strength, as a {@link Boolean}.
      */
     public static boolean isFullStrength(LivingEntity attacker) {
-        return !(attacker instanceof Player player) || player.getAttackStrengthScale(1.0F) == 1.0F;
+        return !(attacker instanceof Player player) || player.getAttackStrengthScale(1.0F) >= 1.0F;
     }
 
     /**


### PR DESCRIPTION
The mod is currently incompatible with Combatify because of the fact that the line `player.getAttackStrengthScale(1.0F) == 1.0F` ensures it is exactly 1.0F, which cannot be true if it exceeds 1.0F. This change doesn't impact vanilla, and allows weapons to use their abilities with Combatify installed.

---

I agree to the Contributor License Agreement (CLA).