### PR TITLE
feat: Add explicit support for Combatify

### DIFF
--- a/src/main/java/com/aetherteam/aether/item/EquipmentUtil.java
+++ b/src/main/java/com/aetherteam/aether/item/EquipmentUtil.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.fml.ModList;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.SlotResult;
 import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
@@ -25,7 +26,8 @@ public final class EquipmentUtil {
      * @return Whether the attack was full strength, as a {@link Boolean}.
      */
     public static boolean isFullStrength(LivingEntity attacker) {
-        return !(attacker instanceof Player player) || player.getAttackStrengthScale(1.0F) >= 1.0F;
+        boolean combatifyLoaded = ModList.get().isLoaded("combatify");
+        return !(attacker instanceof Player player) || (combatifyLoaded ? player.getAttackStrengthScale(1.0F) >= 1.95F : player.getAttackStrengthScale(1.0F) >= 1.0F);
     }
 
     /**


### PR DESCRIPTION
After making the previous PR related to Combatify, I realized that the idea of only enabling abilities from The Aether if an attack is charged wouldn't work with my previous fix, as most attacks require 100% charge anyways when Combatify is installed. This means every ability would activate on every attack. Since this works against the design of The Aether's special abilities, I made this to ensure that those abilities only activate if an attack is "charged" by Combatify's standards. This is normally seen with sweeping or the charged reach bonus, both of which activate on 195% or above, hence why it is 195% or above here too. This won't impede on intended mechanics without Combatify, but will provide a more natural experience with it.

---

I agree to the Contributor License Agreement (CLA).