### PR TITLE
improv: better dev mcfunctions

### DIFF
--- a/src/main/resources/data/aether/functions/dev_powerwash_chunk.mcfunction
+++ b/src/main/resources/data/aether/functions/dev_powerwash_chunk.mcfunction
@@ -1,2 +1,2 @@
-execute at Dev run fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #minecraft:dirt
-execute at Dev run fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #forge:stone
+execute at @p run fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #minecraft:dirt
+execute at @p run fill ~-8 16 ~-8 ~8 128 ~8 minecraft:air replace #forge:stone

--- a/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
+++ b/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
@@ -1,3 +1,3 @@
 execute in aether:the_aether run tp @p ~ ~ ~
 gamemode spectator @p
-effect give @p minecraft:night_vision 9999
+effect give @p minecraft:night_vision infinite

--- a/src/main/resources/data/aether/functions/suit_up.mcfunction
+++ b/src/main/resources/data/aether/functions/suit_up.mcfunction
@@ -1,13 +1,13 @@
 # Suits up the player with equipment that won't break for battle.
-give @p aether:zanite_pickaxe{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
-give @p aether:zanite_sword{Enchantments:[{id:"minecraft:unbreaking", lvl:10}]}
+give @p aether:zanite_pickaxe{Unbreakable:1}
+give @p aether:zanite_sword{Unbreakable:1}
 
 # If the player doesn't already have armor, equip them with gravitite.
-execute unless data entity @p Inventory[{Slot:100b}] run item replace entity @p armor.feet with aether:gravitite_boots{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
-execute unless data entity @p Inventory[{Slot:101b}] run item replace entity @p armor.legs with aether:gravitite_leggings{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
-execute unless data entity @p Inventory[{Slot:102b}] run item replace entity @p armor.chest with aether:gravitite_chestplate{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
-execute unless data entity @p Inventory[{Slot:103b}] run item replace entity @p armor.head with aether:gravitite_helmet{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
-execute unless data entity @p ForgeCaps."curios:inventory".Curios[{Identifier:"aether_gloves"}].StacksHandler.Stacks.Items[0] run curios replace aether_gloves 0 @p with aether:gravitite_gloves{Enchantments:[{id:"minecraft:unbreaking",lvl:10}]}
+execute unless data entity @p Inventory[{Slot:100b}] run item replace entity @p armor.feet with aether:gravitite_boots{Unbreakable:1}
+execute unless data entity @p Inventory[{Slot:101b}] run item replace entity @p armor.legs with aether:gravitite_leggings{Unbreakable:1}
+execute unless data entity @p Inventory[{Slot:102b}] run item replace entity @p armor.chest with aether:gravitite_chestplate{Unbreakable:1}
+execute unless data entity @p Inventory[{Slot:103b}] run item replace entity @p armor.head with aether:gravitite_helmet{Unbreakable:1}
+execute unless data entity @p ForgeCaps."curios:inventory".Curios[{Identifier:"aether_gloves"}].StacksHandler.Stacks.Items[0] run curios replace aether_gloves 0 @p with aether:gravitite_gloves{Unbreakable:1}
 
 give @p aether:skyroot_water_bucket
 give @p aether:enchanted_berry 64


### PR DESCRIPTION
This pull request makes it so `dev_powerwash_chunk.mcfunction` uses `@p` instead of `Dev` as player (makes it consistent with other dev mcfunctions) and makes the unbreakability for gear in `suit_up.mcfunction` not use unbreaking 10 and instead use the unbreakable tag. `setup_structure_hunt.mcfunction` now uses infinite for the night vision instead of 9999 seconds as it seems like it was supposed to be infinite.
---

I agree to the Contributor License Agreement (CLA).
