### PR TITLE
improv: make the night vision in dev mcfunction at least last as long as possible because no infinite on 1.19.2

### DIFF
--- a/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
+++ b/src/main/resources/data/aether/functions/setup_structure_hunt.mcfunction
@@ -1,3 +1,3 @@
 execute in aether:the_aether run tp @p ~ ~ ~
 gamemode spectator @p
-effect give @p minecraft:night_vision 9999
+effect give @p minecraft:night_vision 1000000


### PR DESCRIPTION
**[THIS PR FOR 1.19.2 ONLY]** This PR makes the night vision at least last as long as possible (a million seconds) on 1.19.2 because infinite is only for 1.19.4 or higher. Apologies for not mentioning in #2087 that infinite is only for 1.19.4 or higher.

---

I agree to the Contributor License Agreement (CLA).