### PR TITLE
fix: Adjusted toggleBetweenMenus function to never return null, in or…

### DIFF
--- a/src/main/java/com/aetherteam/aether/client/event/hooks/MenuHooks.java
+++ b/src/main/java/com/aetherteam/aether/client/event/hooks/MenuHooks.java
@@ -130,7 +130,6 @@ public class MenuHooks {
             return AetherConfig.CLIENT.default_minecraft_menu.get();
         }
         return AetherConfig.CLIENT.default_aether_menu.get();
-
     }
 
     /**

--- a/src/main/java/com/aetherteam/aether/client/event/hooks/MenuHooks.java
+++ b/src/main/java/com/aetherteam/aether/client/event/hooks/MenuHooks.java
@@ -125,15 +125,12 @@ public class MenuHooks {
      *
      * @return The {@link String} for the menu's ID.
      */
-    @Nullable
     private static String toggleBetweenMenus() {
         if (AetherMenuUtil.isAetherMenu()) {
             return AetherConfig.CLIENT.default_minecraft_menu.get();
-        } else if (AetherMenuUtil.isMinecraftMenu()) {
-            return AetherConfig.CLIENT.default_aether_menu.get();
-        } else {
-            return null;
         }
+        return AetherConfig.CLIENT.default_aether_menu.get();
+
     }
 
     /**


### PR DESCRIPTION
fix: Adjusted toggleBetweenMenus function to never return null, in order to fix menu button not working when other mods adjust active_menu

closes issue #2181


I agree to the Contributor License Agreement (CLA).