### PR TITLE
Fixed crash when applying Gold Dungeon's SurfaceRuleProcessor to a modded biome

### DIFF
--- a/src/main/java/com/aetherteam/aether/world/processor/SurfaceRuleProcessor.java
+++ b/src/main/java/com/aetherteam/aether/world/processor/SurfaceRuleProcessor.java
@@ -54,7 +54,7 @@ public class SurfaceRuleProcessor extends StructureProcessor {
                     NoiseChunk noisechunk = ((ChunkAccessAccessor) chunkAccess).aether$getNoiseChunk();
                     if (noisechunk != null) {
                         CarvingContext carvingcontext = new CarvingContext(noiseBasedChunkGenerator, worldGenLevel.registryAccess(), chunkAccess.getHeightAccessorForGeneration(), noisechunk, serverChunkCache.randomState(), surfaceRule);
-                        Optional<BlockState> state = carvingcontext.topMaterial(worldGenLevel.getBiomeManager()::getBiome, chunkAccess, modifiedBlockInfo.pos(), false);
+                        Optional<BlockState> state = carvingcontext.topMaterial(worldGenLevel.getBiomeManager()::getNoiseBiomeAtPosition, chunkAccess, modifiedBlockInfo.pos(), false);
                         if (state.isPresent()) {
                             if (modifiedBlockInfo.state().is(AetherTags.Blocks.AETHER_DIRT) && !modifiedBlockInfo.state().is(AetherBlocks.AETHER_DIRT.get()) && state.get().is(AetherTags.Blocks.AETHER_DIRT)) {
                                 return new StructureTemplate.StructureBlockInfo(modifiedBlockInfo.pos(), state.get(), null);


### PR DESCRIPTION
This pr resolves an issue regarding the SurfaceRuleProcessor used for the Gold Dungeon structure, when applied to a modded biome, due to the chunk not being present while generating the dungeon. This issue also applies if the Gold Dungeon is being generated in the overworld through a datapack. This issue is only present in version 1.21.+.

I agree to the Contributor License Agreement (CLA).