### PR TITLE
Fix #2365

### DIFF
--- a/src/main/java/com/aetherteam/aether/world/structure/LargeAercloudStructure.java
+++ b/src/main/java/com/aetherteam/aether/world/structure/LargeAercloudStructure.java
@@ -83,6 +83,9 @@ public class LargeAercloudStructure extends Structure {
         int finalY = y;
         Direction orientation = Direction.Plane.HORIZONTAL.getRandomDirection(context.random());
         chunks.forEach((chunkPos, blockPosSet) -> {
+            if (blockPosSet.isEmpty()) { // Skip creating StructurePiece if there are no blocks to place
+                return;
+            }
             BoundingBox boundingBox = new BoundingBox(chunkPos.getMinBlockX(), Math.max(initialY - 16, 0), chunkPos.getMinBlockZ(), chunkPos.getMaxBlockX(), finalY + 16, chunkPos.getMaxBlockZ());
             builder.addPiece(new LargeAercloudChunk(blockPosSet, blocks, boundingBox, orientation));
         });

--- a/src/main/java/com/aetherteam/aether/world/structurepiece/LargeAercloudChunk.java
+++ b/src/main/java/com/aetherteam/aether/world/structurepiece/LargeAercloudChunk.java
@@ -36,10 +36,11 @@ public class LargeAercloudChunk extends StructurePiece {
 
     public LargeAercloudChunk(StructurePieceSerializationContext context, CompoundTag tag) {
         super(AetherStructurePieceTypes.LARGE_AERCLOUD.get(), tag);
-        ListTag positions = tag.getList("Positions", Tag.TAG_COMPOUND);
-        for (int i = 0; i < positions.size(); i++) {
-            Tag position = positions.get(i);
-            NbtUtils.readBlockPos((CompoundTag) position, String.valueOf(i)).ifPresent(this.positions::add);
+
+        ListTag positions = tag.getList("Positions", Tag.TAG_INT_ARRAY);
+        for (Tag value : positions) {
+            int[] position = ((IntArrayTag) value).getAsIntArray();
+            this.positions.add(new BlockPos(position[0], position[1], position[2]));
         }
         this.blocks = BlockStateProvider.CODEC.parse(new Dynamic<>(NbtOps.INSTANCE, tag.get("Blocks"))).getPartialOrThrow();
     }


### PR DESCRIPTION
Fixes Clouds not generating around Silver Dungeons, which is a non-deterministic worldgen bug caused by incomplete generation such as closing the save or structure being on edge of a passerby's chunk-loading.

There is also an additional measure to skip creation of Cloud structure pieces, if they will not place any blocks.

Fixes #2365