### PR TITLE
fix: Inability to sync if tools are debuffed to the player mining blocks

### DIFF
--- a/src/main/java/com/aetherteam/aether/client/AetherClient.java
+++ b/src/main/java/com/aetherteam/aether/client/AetherClient.java
@@ -14,6 +14,7 @@ import com.aetherteam.aether.client.renderer.AetherRenderers;
 import com.aetherteam.aether.client.renderer.level.AetherRenderEffects;
 import com.aetherteam.aether.data.resources.registries.AetherDimensions;
 import com.aetherteam.aether.entity.AetherEntityTypes;
+import com.aetherteam.aether.event.hooks.AbilityHooks;
 import com.aetherteam.aether.inventory.menu.AetherMenuTypes;
 import com.aetherteam.aether.inventory.menu.LoreBookMenu;
 import com.aetherteam.aether.item.AetherItems;
@@ -32,6 +33,7 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.RegisterDimensionTransitionScreenEvent;
 import net.neoforged.neoforge.client.event.RegisterEntitySpectatorShadersEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -131,6 +133,8 @@ public class AetherClient {
         LevelClientListener.listen(bus);
         MenuListener.listen(bus);
         WorldPreviewListener.listen(bus);
+
+        bus.addListener((ClientPlayerNetworkEvent.LoggingOut event) -> AbilityHooks.ToolHooks.resetDebuffToolsState());
 
         neoBus.addListener(AetherMenuTypes::registerMenuScreens);
         neoBus.addListener(AetherColorResolvers::registerBlockColor);

--- a/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/AbilityHooks.java
@@ -311,12 +311,6 @@ public class AbilityHooks {
          * @see com.aetherteam.aether.event.listeners.abilities.ToolAbilityListener#modifyBreakSpeed(PlayerEvent.BreakSpeed)
          */
         public static float reduceToolEffectiveness(Player player, BlockState state, ItemStack stack, float speed) {
-            if (AetherConfig.SERVER.tools_debuff.get()) {
-                if (!player.level().isClientSide() && player.level() instanceof ServerLevel serverLevel && player instanceof ServerPlayer serverPlayer) {
-                    debuffTools = true;
-                    PacketDistributor.sendToPlayersNear(serverLevel, serverPlayer, player.getX(), player.getY(), player.getZ(), 10, new ToolDebuffPacket(true));
-                }
-            }
             if (debuffTools) {
                 if ((state.getBlock().getDescriptionId().startsWith("block.aether.") || state.is(AetherTags.Blocks.TREATED_AS_AETHER_BLOCK)) && !state.is(AetherTags.Blocks.TREATED_AS_VANILLA_BLOCK)) {
                     if (!stack.isEmpty() && stack.isCorrectToolForDrops(state) && !stack.getItem().getDescriptionId().startsWith("item.aether.") && !stack.is(AetherTags.Items.TREATED_AS_AETHER_ITEM)) {
@@ -325,6 +319,30 @@ public class AbilityHooks {
                 }
             }
             return speed;
+        }
+
+        /**
+         * Sets up the debuff tool state based on the current server value and attempts to sync the state to the client if needed
+         *
+         * @param player Current player logging into the server
+         * @see com.aetherteam.aether.event.listeners.abilities.ToolAbilityListener#
+         */
+        public static void setDebuffToolsState(ServerPlayer player) {
+            if (debuffTools) {
+                PacketDistributor.sendToPlayer(player, new ToolDebuffPacket(true));
+            } else if (AetherConfig.SERVER.tools_debuff.get()) {
+                debuffTools = true;
+
+                PacketDistributor.sendToAllPlayers(new ToolDebuffPacket(true));
+            }
+        }
+
+        /**
+         * Method used to reset the debuffTools state to false on player logout
+         * @see com.aetherteam.aether.client.AetherClient#eventSetup(net.neoforged.bus.api.IEventBus)
+         */
+        public static void resetDebuffToolsState() {
+            debuffTools = false;
         }
 
         /**

--- a/src/main/java/com/aetherteam/aether/event/listeners/abilities/ToolAbilityListener.java
+++ b/src/main/java/com/aetherteam/aether/event/listeners/abilities/ToolAbilityListener.java
@@ -3,6 +3,7 @@ package com.aetherteam.aether.event.listeners.abilities;
 import com.aetherteam.aether.Aether;
 import com.aetherteam.aether.event.hooks.AbilityHooks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
@@ -10,6 +11,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
@@ -22,6 +24,7 @@ public class ToolAbilityListener {
         bus.addListener(ToolAbilityListener::setupToolModifications);
         bus.addListener(ToolAbilityListener::doHolystoneAbility);
         bus.addListener(ToolAbilityListener::modifyBreakSpeed);
+        bus.addListener(ToolAbilityListener::setupDebuffToolState);
         bus.addListener(ToolAbilityListener::doGoldenOakStripping);
     }
 
@@ -65,6 +68,10 @@ public class ToolAbilityListener {
             event.setNewSpeed(AbilityHooks.ToolHooks.handleZaniteToolAbility(itemStack, event.getNewSpeed()));
             event.setNewSpeed(AbilityHooks.ToolHooks.reduceToolEffectiveness(player, blockState, itemStack, event.getNewSpeed()));
         }
+    }
+
+    public static void setupDebuffToolState(PlayerEvent.PlayerLoggedInEvent event) {
+        AbilityHooks.ToolHooks.setDebuffToolsState((ServerPlayer) event.getEntity());
     }
 
     /**


### PR DESCRIPTION
Overall fixes issues where mining speed would be desynced between a client and server when debuffed tools were enabled under common conditions when on a server

---

I agree to the Contributor License Agreement (CLA).
