### PR TITLE
fix: immersive portals compatibility

### DIFF
--- a/src/main/resources/data/aether/custom_portal_generation/skyroot_water_bucket_create_aether_portal.json
+++ b/src/main/resources/data/aether/custom_portal_generation/skyroot_water_bucket_create_aether_portal.json
@@ -7,7 +7,7 @@
   "form": {
     "type": "imm_ptl:heterogeneous",
     "area_block": "minecraft:air",
-    "frame_block": "#aether:aether_portal_blocks",
+    "frame_block": "aether:aether_portal_blocks",
     "generate_frame_if_not_found": true
   },
   "trigger": {

--- a/src/main/resources/data/aether/custom_portal_generation/water_bucket_create_aether_portal.json
+++ b/src/main/resources/data/aether/custom_portal_generation/water_bucket_create_aether_portal.json
@@ -7,7 +7,7 @@
   "form": {
     "type": "imm_ptl:heterogeneous",
     "area_block": "minecraft:air",
-    "frame_block": "#aether:aether_portal_blocks",
+    "frame_block": "aether:aether_portal_blocks",
     "generate_frame_if_not_found": true
   },
   "trigger": {


### PR DESCRIPTION
I was testing this by manually copying the json files into The Aether's jar, and running it on ~~NeoForge~~ Forge on 1.19.2 (a modified CottageWitch pack)

I am not sure if this is also required for later versions of MC / iPortals

Fixes this error I saw on my client:

>   Non [a-z0-9_.-] character in namespace of location: #aether:aether_portal_blocks

[Full log link](https://mclo.gs/Hom59MB)

See https://github.com/The-Aether-Team/The-Aether/commit/df0f6f486063153f21015ab57e00f7f7f9664435#r150773259

---

I agree to the Contributor License Agreement (CLA).
