### PR TITLE
fix: aerogel walls culling blocks they shouldn't

### DIFF
--- a/src/main/java/com/aetherteam/aether/block/AetherBlocks.java
+++ b/src/main/java/com/aetherteam/aether/block/AetherBlocks.java
@@ -183,7 +183,7 @@ public class AetherBlocks {
     public static final DeferredBlock<WallBlock> MOSSY_HOLYSTONE_WALL = register("mossy_holystone_wall", () -> new WallBlock(Block.Properties.ofFullCopy(AetherBlocks.MOSSY_HOLYSTONE.get()).forceSolidOn()));
     public static final DeferredBlock<WallBlock> ICESTONE_WALL = register("icestone_wall", () -> new IcestoneWallBlock(Block.Properties.ofFullCopy(AetherBlocks.ICESTONE.get()).forceSolidOn()));
     public static final DeferredBlock<WallBlock> HOLYSTONE_BRICK_WALL = register("holystone_brick_wall", () -> new WallBlock(Block.Properties.ofFullCopy(AetherBlocks.HOLYSTONE_BRICKS.get()).forceSolidOn()));
-    public static final DeferredBlock<WallBlock> AEROGEL_WALL = register("aerogel_wall", () -> new AerogelWallBlock(Block.Properties.of().mapColor(MapColor.DIAMOND).forceSolidOn().instrument(NoteBlockInstrument.BASEDRUM).strength(1.0F, 2000.0F).sound(SoundType.METAL).requiresCorrectToolForDrops().isViewBlocking(AetherBlocks::never)));
+    public static final DeferredBlock<WallBlock> AEROGEL_WALL = register("aerogel_wall", () -> new AerogelWallBlock(Block.Properties.of().mapColor(MapColor.DIAMOND).forceSolidOn().instrument(NoteBlockInstrument.BASEDRUM).strength(1.0F, 2000.0F).sound(SoundType.METAL).requiresCorrectToolForDrops().isViewBlocking(AetherBlocks::never).noOcclusion()));
 
     public static final DeferredBlock<StairBlock> SKYROOT_STAIRS = register("skyroot_stairs",
             () -> new StairBlock(SKYROOT_PLANKS.get().defaultBlockState(), Block.Properties.ofFullCopy(AetherBlocks.SKYROOT_PLANKS.get())));

--- a/src/main/java/com/aetherteam/aether/block/construction/AerogelWallBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/construction/AerogelWallBlock.java
@@ -5,11 +5,25 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.WallBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.WallSide;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 public class AerogelWallBlock extends WallBlock {
+    private static final Map<Direction, EnumProperty<WallSide>> WALL_SIDES_BY_DIRECTION = new EnumMap<>(Direction.class);
+
+    static {
+        WALL_SIDES_BY_DIRECTION.put(Direction.NORTH, NORTH_WALL);
+        WALL_SIDES_BY_DIRECTION.put(Direction.SOUTH, SOUTH_WALL);
+        WALL_SIDES_BY_DIRECTION.put(Direction.EAST, EAST_WALL);
+        WALL_SIDES_BY_DIRECTION.put(Direction.WEST, WEST_WALL);
+    }
+
     public AerogelWallBlock(Properties properties) {
         super(properties);
     }
@@ -39,6 +53,18 @@ public class AerogelWallBlock extends WallBlock {
      * This prevents adjacent walls from rendering redundant faces.
      */
     protected boolean skipRendering(BlockState state, BlockState adjacentBlockState, Direction side) {
-        return adjacentBlockState.is(this) || super.skipRendering(state, adjacentBlockState, side);
+        if (adjacentBlockState.is(this)) {
+            if (side.getAxis().isHorizontal()) {
+                // Verify that both walls have the same height. This avoids culling a face that actually sticks out
+                // above another face.
+                WallSide ourHeight = state.getValue(WALL_SIDES_BY_DIRECTION.get(side));
+                WallSide theirHeight = adjacentBlockState.getValue(WALL_SIDES_BY_DIRECTION.get(side.getOpposite()));
+                return ourHeight.ordinal() <= theirHeight.ordinal();
+            } else {
+                // If we render a tall post face, the wall above must also have a tall post to skip rendering
+                return !state.getValue(UP) || adjacentBlockState.getValue(UP);
+            }
+        }
+        return super.skipRendering(state, adjacentBlockState, side);
     }
 }

--- a/src/main/java/com/aetherteam/aether/block/construction/AerogelWallBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/construction/AerogelWallBlock.java
@@ -1,6 +1,7 @@
 package com.aetherteam.aether.block.construction;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.WallBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -30,5 +31,14 @@ public class AerogelWallBlock extends WallBlock {
     @Override
     public VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return Shapes.empty();
+    }
+
+    /**
+     * [CODE COPY] - {@link net.minecraft.world.level.block.HalfTransparentBlock#skipRendering(BlockState, BlockState, Direction)}.
+     *
+     * This prevents adjacent walls from rendering redundant faces.
+     */
+    protected boolean skipRendering(BlockState state, BlockState adjacentBlockState, Direction side) {
+        return adjacentBlockState.is(this) || super.skipRendering(state, adjacentBlockState, side);
     }
 }


### PR DESCRIPTION
Fixes #1934. The strategy is to mark the blocks as `noOcclusion` (which I believe is more correct - they are translucent, so they won't ever be occluding geometry behind them) and then use `skipRendering` so they skip rendering their face when touching a wall of the exact same type.

