### PR TITLE
fix: Null safety in DoubleDrops

### DIFF
--- a/src/main/java/com/aetherteam/aether/loot/functions/DoubleDrops.java
+++ b/src/main/java/com/aetherteam/aether/loot/functions/DoubleDrops.java
@@ -33,11 +33,10 @@ public class DoubleDrops extends LootItemConditionalFunction {
         Level level = context.getLevel();
         ItemStack toolStack = context.getParamOrNull(LootContextParams.TOOL);
         BlockState blockState = context.getParamOrNull(LootContextParams.BLOCK_STATE);
-        if (toolStack.getItem() instanceof SkyrootTool skyrootTool) {
+        if (toolStack != null && toolStack.getItem() instanceof SkyrootTool skyrootTool) {
             return skyrootTool.doubleDrops(level, stack, toolStack, blockState);
-        } else {
-            return stack;
         }
+        return stack;
     }
 
     public static LootItemConditionalFunction.Builder<?> builder() {


### PR DESCRIPTION
Adds basic null safety to double drops, as discussed in #2474. As the crash seems to be back in the released version, this is necessary.

closes issue #2474

---

I agree to the Contributor License Agreement (CLA).