### PR TITLE
WIP fix for portal client-server desync: type(feat): Incomplete but fixes dimension sync issue

### DIFF
--- a/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
@@ -97,7 +97,7 @@ public class AetherPortalBlock extends Block {
 			ServerLevel destinationLevel = server.getLevel(destinationKey);
 			if (destinationLevel != null && !entity.isPassenger()) {
 				entity.level().getProfiler().push("aether_portal");
-				entity.changeDimension(destinationLevel, new AetherPortalForcer(destinationLevel, true)); // running this still updates the player's position to the correct one
+				entity.changeDimension(server.getLevel(entity.level().dimension()), new AetherPortalForcer(destinationLevel, true));
 				teleportToDimension(entity, destinationLevel, entity.position(), entity.getDeltaMovement());
 				entity.setPortalCooldown();
 				entity.level().getProfiler().pop();

--- a/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
@@ -36,6 +36,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.Optional;
 
+import static com.aetherteam.aether.event.hooks.DimensionHooks.teleportToDimension;
+
 public class AetherPortalBlock extends Block {
 	public static final EnumProperty<Direction.Axis> AXIS = BlockStateProperties.HORIZONTAL_AXIS;
 	protected static final VoxelShape X_AXIS_AABB = Block.box(0.0, 0.0, 6.0, 16.0, 16.0, 10.0);
@@ -95,8 +97,9 @@ public class AetherPortalBlock extends Block {
 			ServerLevel destinationLevel = server.getLevel(destinationKey);
 			if (destinationLevel != null && !entity.isPassenger()) {
 				entity.level().getProfiler().push("aether_portal");
+				teleportToDimension(entity, destinationLevel, entity.position(), entity.getDeltaMovement());
 				entity.setPortalCooldown();
-				entity.changeDimension(destinationLevel, new AetherPortalForcer(destinationLevel, true));
+				entity.changeDimension(destinationLevel, new AetherPortalForcer(destinationLevel, true)); // running this still updates the player's position to the correct one
 				entity.level().getProfiler().pop();
 			}
 		}

--- a/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
+++ b/src/main/java/com/aetherteam/aether/block/portal/AetherPortalBlock.java
@@ -97,9 +97,9 @@ public class AetherPortalBlock extends Block {
 			ServerLevel destinationLevel = server.getLevel(destinationKey);
 			if (destinationLevel != null && !entity.isPassenger()) {
 				entity.level().getProfiler().push("aether_portal");
+				entity.changeDimension(destinationLevel, new AetherPortalForcer(destinationLevel, true)); // running this still updates the player's position to the correct one
 				teleportToDimension(entity, destinationLevel, entity.position(), entity.getDeltaMovement());
 				entity.setPortalCooldown();
-				entity.changeDimension(destinationLevel, new AetherPortalForcer(destinationLevel, true)); // running this still updates the player's position to the correct one
 				entity.level().getProfiler().pop();
 			}
 		}

--- a/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
@@ -51,15 +51,10 @@ public class DimensionHooks {
     public static int teleportationTimer;
 
     public static void teleportToDimension(Entity entity, ServerLevel destinationLevel, Vec3 position, Vec3 velocity) {
-        /*Level serverLevel = entity.level();
-        MinecraftServer minecraftserver = serverLevel.getServer();
-        if (minecraftserver!=null) {
-            ServerLevel destinationLevel = minecraftserver.getLevel(destinationLevelKey);*/
         if (destinationLevel!=null) {
-            entity.teleportTo(destinationLevel, position.x(), position.x(), position.z(), EnumSet.noneOf(RelativeMovement.class), entity.getYRot(), entity.getXRot());
+            entity.teleportTo(destinationLevel, position.x(), position.y(), position.z(), EnumSet.noneOf(RelativeMovement.class), entity.getYRot(), entity.getXRot());
             entity.setDeltaMovement(velocity);
             entity.hurtMarked = true;
-            //}
         }
     }
 

--- a/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
@@ -71,7 +71,7 @@ public class DimensionHooks {
                     if (aetherPlayer.getPlayer() instanceof ServerPlayer serverPlayer) {
                         MinecraftServer server = serverPlayer.level().getServer();
                         ServerLevel aetherLevel = server.getLevel(AetherDimensions.AETHER_LEVEL);
-                        if (aetherLevel != null && serverPlayer.level().dimension() != AetherDimensions.AETHER_LEVEL) {
+                        if (aetherLevel != null && serverPlayer.level().dimension() == Level.OVERWORLD) {
                             if (aetherPlayer.getPlayer().changeDimension(aetherLevel, new AetherPortalForcer(aetherLevel, false, true)) != null) {
                                 serverPlayer.setRespawnPosition(AetherDimensions.AETHER_LEVEL, serverPlayer.blockPosition(), serverPlayer.getYRot(), true, false);
                                 aetherPlayer.setCanSpawnInAether(false); // Sets that the player has already spawned in the Aether.

--- a/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
+++ b/src/main/java/com/aetherteam/aether/event/hooks/DimensionHooks.java
@@ -34,6 +34,13 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.entity.RelativeMovement;
+import net.minecraft.world.level.portal.PortalInfo;
+import net.minecraft.world.level.portal.PortalShape;
+import java.util.EnumSet;
+import java.util.function.Function;
+import java.util.Objects;
 
 import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
@@ -42,6 +49,19 @@ public class DimensionHooks {
     public static boolean playerLeavingAether;
     public static boolean displayAetherTravel;
     public static int teleportationTimer;
+
+    public static void teleportToDimension(Entity entity, ServerLevel destinationLevel, Vec3 position, Vec3 velocity) {
+        /*Level serverLevel = entity.level();
+        MinecraftServer minecraftserver = serverLevel.getServer();
+        if (minecraftserver!=null) {
+            ServerLevel destinationLevel = minecraftserver.getLevel(destinationLevelKey);*/
+        if (destinationLevel!=null) {
+            entity.teleportTo(destinationLevel, position.x(), position.x(), position.z(), EnumSet.noneOf(RelativeMovement.class), entity.getYRot(), entity.getXRot());
+            entity.setDeltaMovement(velocity);
+            entity.hurtMarked = true;
+            //}
+        }
+    }
 
     /**
      * Spawns the player in the Aether dimension if the {@link AetherConfig.Server#spawn_in_aether} config is enabled.
@@ -52,6 +72,7 @@ public class DimensionHooks {
         AetherPlayer.getOptional(player).ifPresent(aetherPlayer -> {
             if (AetherConfig.SERVER.spawn_in_aether.get()) {
                 if (aetherPlayer.canSpawnInAether()) { // Checks if the player has been set to spawn in the Aether.
+                    //TODO: replace this with teleportToDimension
                     if (aetherPlayer.getPlayer() instanceof ServerPlayer serverPlayer) {
                         MinecraftServer server = serverPlayer.level().getServer();
                         ServerLevel aetherLevel = server.getLevel(AetherDimensions.AETHER_LEVEL);

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
@@ -21,6 +21,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.entity.EntityTypeTest;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,6 +30,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 import java.util.Optional;
+
+import static com.aetherteam.aether.event.hooks.DimensionHooks.teleportToDimension;
 
 @Mixin(Entity.class)
 public class EntityMixin {
@@ -78,10 +81,15 @@ public class EntityMixin {
             if (destination != null && LevelUtil.returnDimension() != LevelUtil.destinationDimension()) {
                 List<Entity> passengers = entity.getPassengers();
                 serverLevel.getProfiler().push("aether_fall");
+                Vec3 position = entity.position();
+                position = new Vec3(position.x(), destination.getMaxBuildHeight() + 160, position.z()); // change entity position to biuld height
+                teleportToDimension(entity, destination, position, entity.getDeltaMovement()); // Running this Properly Teleports the player, though I don't think it syncs capabilities properly
                 entity.setPortalCooldown();
-                Entity target = entity.changeDimension(destination, new AetherPortalForcer(destination, false));
+                //Entity target = entity; // passenger isn't being sent correctly still. replace the portal code with the teleport code.
                 serverLevel.getProfiler().pop();
                 // Check for passengers.
+
+                /* // Something in here is setting player position to y=16
                 if (target != null) {
                     for (Entity passenger : passengers) {
                         passenger.stopRiding();
@@ -97,7 +105,9 @@ public class EntityMixin {
                         DimensionHooks.teleportationTimer = 500; // Sets a timer marking that the player teleported from falling out of the Aether.
                     }
                 }
-                return target;
+
+                 */
+                return entity;
             }
         }
         return null;

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
@@ -85,11 +85,11 @@ public class EntityMixin {
                 position = new Vec3(position.x(), destination.getMaxBuildHeight() + 160, position.z()); // change entity position to biuld height
                 teleportToDimension(entity, destination, position, entity.getDeltaMovement()); // Running this Properly Teleports the player, though I don't think it syncs capabilities properly
                 entity.setPortalCooldown();
-                //Entity target = entity; // passenger isn't being sent correctly still. replace the portal code with the teleport code.
+                Entity target = entity; // passenger isn't being sent correctly still. replace the portal code with the teleport code.
                 serverLevel.getProfiler().pop();
                 // Check for passengers.
 
-                /* // Something in here is setting player position to y=16
+
                 if (target != null) {
                     for (Entity passenger : passengers) {
                         passenger.stopRiding();
@@ -106,7 +106,7 @@ public class EntityMixin {
                     }
                 }
 
-                 */
+
                 return entity;
             }
         }

--- a/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
+++ b/src/main/java/com/aetherteam/aether/mixin/mixins/common/EntityMixin.java
@@ -88,8 +88,6 @@ public class EntityMixin {
                 Entity target = entity; // passenger isn't being sent correctly still. replace the portal code with the teleport code.
                 serverLevel.getProfiler().pop();
                 // Check for passengers.
-
-
                 if (target != null) {
                     for (Entity passenger : passengers) {
                         passenger.stopRiding();
@@ -105,8 +103,6 @@ public class EntityMixin {
                         DimensionHooks.teleportationTimer = 500; // Sets a timer marking that the player teleported from falling out of the Aether.
                     }
                 }
-
-
                 return entity;
             }
         }


### PR DESCRIPTION
… by reusing base teleportation logic + hurtmarked

`(WIP fix for portal client-server desync)`: type(feat): Brief description *[MOVE TO TITLE]*

This doesn't work with passengers atm, and is putting players at weird y levels when 'falling' - there's an issue as well with Spawn Items being given multiple times, working on it

---

I agree to the Contributor License Agreement (CLA).