### PR TITLE
Fix ClassCastException in drop modifiers

### DIFF
--- a/src/main/java/com/aetherteam/aether/loot/modifiers/DoubleDropsModifier.java
+++ b/src/main/java/com/aetherteam/aether/loot/modifiers/DoubleDropsModifier.java
@@ -13,14 +13,14 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 
 public class DoubleDropsModifier extends LootModifier {
-    //public static final MapCodec<DoubleDropsModifier> CODEC = RecordCodecBuilder.mapCodec((instance) -> LootModifier.codecStart(instance).apply(instance, DoubleDropsModifier::new));
-
     public DoubleDropsModifier(LootItemCondition[] conditions) {
         super(conditions);
     }
 
     /**
-     * Doubles mob drops if a mob is attacked with full strength with an item that implements {@link SkyrootWeapon} if the mob isn't tagged with {@link AetherTags.Entities#NO_SKYROOT_DOUBLE_DROPS} and the item isn't tagged with {@link AetherTags.Items#NO_SKYROOT_DOUBLE_DROPS}.
+     * Doubles mob drops if a mob is attacked with full strength with an item that implements {@link SkyrootWeapon}
+     * if the mob isn't tagged with {@link AetherTags.Entities#NO_SKYROOT_DOUBLE_DROPS} and the item isn't tagged
+     * with {@link AetherTags.Items#NO_SKYROOT_DOUBLE_DROPS}.
      *
      * @param lootStacks Result items from a loot table as an {@link ObjectArrayList} of {@link ItemStack}s.
      * @param context    The {@link LootContext}.
@@ -28,23 +28,31 @@ public class DoubleDropsModifier extends LootModifier {
      */
     @Override
     public ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> lootStacks, LootContext context) {
-        Entity entity = context.getParamOrNull(LootContextParams.DIRECT_ATTACKING_ENTITY);
-        Entity target = context.getParamOrNull(LootContextParams.THIS_ENTITY);
         ObjectArrayList<ItemStack> newStacks = new ObjectArrayList<>(lootStacks);
-        if (entity instanceof LivingEntity livingEntity && target != null) {
-            if (EquipmentUtil.isFullStrength(livingEntity) && livingEntity.getMainHandItem().getItem() instanceof SkyrootWeapon && !target.getType().is(AetherTags.Entities.NO_SKYROOT_DOUBLE_DROPS)) {
-                for (ItemStack stack : lootStacks) {
-                    if (!stack.is(AetherTags.Items.NO_SKYROOT_DOUBLE_DROPS)) {
-                        newStacks.add(stack);
-                    }
+
+        // Get the entity that was killed
+        Entity target = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (target == null) {
+            return newStacks; // Return original loot if no target entity
+        }
+
+        // Get the attacking entity, which could be null or a DamageSource
+        Object attacker = context.getParamOrNull(LootContextParams.DIRECT_ATTACKING_ENTITY);
+        if (!(attacker instanceof LivingEntity livingEntity)) {
+            return newStacks; // Return original loot if attacker is not a LivingEntity
+        }
+
+        // Check conditions for doubling drops
+        if (EquipmentUtil.isFullStrength(livingEntity)
+            && livingEntity.getMainHandItem().getItem() instanceof SkyrootWeapon
+            && !target.getType().is(AetherTags.Entities.NO_SKYROOT_DOUBLE_DROPS)) {
+            for (ItemStack stack : lootStacks) {
+                if (!stack.is(AetherTags.Items.NO_SKYROOT_DOUBLE_DROPS)) {
+                    newStacks.add(stack.copy()); // Add a copy to avoid modifying the original stack
                 }
             }
         }
+
         return newStacks;
     }
-
-//    @Override
-//    public MapCodec<? extends IGlobalLootModifier> codec() {
-//        return DoubleDropsModifier.CODEC;
-//    }
 }

--- a/src/main/java/com/aetherteam/aether/loot/modifiers/PigDropsModifier.java
+++ b/src/main/java/com/aetherteam/aether/loot/modifiers/PigDropsModifier.java
@@ -13,14 +13,14 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 
 public class PigDropsModifier extends LootModifier {
-//    public static final MapCodec<PigDropsModifier> CODEC = RecordCodecBuilder.mapCodec((instance) -> LootModifier.codecStart(instance).apply(instance, PigDropsModifier::new));
-
     public PigDropsModifier(LootItemCondition[] conditions) {
         super(conditions);
     }
 
     /**
-     * Doubles pig drops with a 1/4 chance if a mob is attacked with full strength with a Pig Slayer and the mob is tagged with {@link AetherTags.Entities#PIGS} and the item is tagged with {@link AetherTags.Items#PIG_DROPS}.
+     * Doubles pig drops with a 1/4 chance if a mob is attacked with full strength with a Pig Slayer
+     * and the mob is tagged with {@link AetherTags.Entities#PIGS} and the item is tagged with
+     * {@link AetherTags.Items#PIG_DROPS}.
      *
      * @param lootStacks Result items from a loot table as an {@link ObjectArrayList} of {@link ItemStack}s.
      * @param context    The {@link LootContext}.
@@ -28,25 +28,32 @@ public class PigDropsModifier extends LootModifier {
      */
     @Override
     public ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> lootStacks, LootContext context) {
-        Entity entity = context.getParamOrNull(LootContextParams.DIRECT_ATTACKING_ENTITY);
-        Entity target = context.getParamOrNull(LootContextParams.THIS_ENTITY);
         ObjectArrayList<ItemStack> newStacks = new ObjectArrayList<>(lootStacks);
-        if (entity instanceof LivingEntity livingEntity && target instanceof LivingEntity livingTarget) {
-            if (EquipmentUtil.isFullStrength(livingEntity) && livingEntity.getMainHandItem().is(AetherItems.PIG_SLAYER.get()) && livingTarget.getType().is(AetherTags.Entities.PIGS) && livingTarget.getRandom().nextInt(4) == 0) {
-                for (ItemStack stack : lootStacks) {
-                    if (stack.is(AetherTags.Items.PIG_DROPS)) {
-                        newStacks.add(stack);
-                    }
+
+        // Get the entity that was killed
+        Entity target = context.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (!(target instanceof LivingEntity livingTarget)) {
+            return newStacks; // Return original loot if target is not a LivingEntity
+        }
+
+        // Get the attacking entity, which could be null or a DamageSource
+        Object attacker = context.getParamOrNull(LootContextParams.DIRECT_ATTACKING_ENTITY);
+        if (!(attacker instanceof LivingEntity livingEntity)) {
+            return newStacks; // Return original loot if attacker is not a LivingEntity
+        }
+
+        // Check conditions for doubling drops
+        if (EquipmentUtil.isFullStrength(livingEntity)
+            && livingEntity.getMainHandItem().is(AetherItems.PIG_SLAYER.get())
+            && livingTarget.getType().is(AetherTags.Entities.PIGS)
+            && livingTarget.getRandom().nextInt(4) == 0) {
+            for (ItemStack stack : lootStacks) {
+                if (stack.is(AetherTags.Items.PIG_DROPS)) {
+                    newStacks.add(stack.copy()); // Add a copy to avoid modifying the original stack
                 }
             }
         }
 
-
         return newStacks;
     }
-
-//    @Override
-//    public MapCodec<? extends IGlobalLootModifier> codec() {
-//        return PigDropsModifier.CODEC;
-//    }
 }


### PR DESCRIPTION
Fixes server crash I encountered [https://pastebin.com/raw/J1FSMUCW](https://pastebin.com/raw/J1FSMUCW) and also similar one in DoubleDropsModifier.

I agree to the Contributor License Agreement (CLA).