### PR TITLE
fix: capability not allowing filling by milk

### DIFF
--- a/src/main/java/com/aetherteam/aether/item/AetherItems.java
+++ b/src/main/java/com/aetherteam/aether/item/AetherItems.java
@@ -356,6 +356,7 @@ public class AetherItems {
         SkyrootBucketItem.REPLACEMENTS.put(() -> Items.TROPICAL_FISH_BUCKET, AetherItems.SKYROOT_TROPICAL_FISH_BUCKET);
         SkyrootBucketItem.REPLACEMENTS.put(() -> Items.AXOLOTL_BUCKET, AetherItems.SKYROOT_AXOLOTL_BUCKET);
         SkyrootBucketItem.REPLACEMENTS.put(() -> Items.TADPOLE_BUCKET, AetherItems.SKYROOT_TADPOLE_BUCKET);
+        SkyrootBucketItem.REPLACEMENTS.put(() -> Items.MILK_BUCKET, AetherItems.SKYROOT_MILK_BUCKET);
     }
 
     public static ItemStack createSwetBannerItemStack(HolderGetter<BannerPattern> patternRegistry) {

--- a/src/main/java/com/aetherteam/aether/item/miscellaneous/bucket/SkyrootBucketWrapper.java
+++ b/src/main/java/com/aetherteam/aether/item/miscellaneous/bucket/SkyrootBucketWrapper.java
@@ -3,6 +3,7 @@ package com.aetherteam.aether.item.miscellaneous.bucket;
 import com.aetherteam.aether.AetherTags;
 import com.aetherteam.aether.item.AetherItems;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
 import net.neoforged.neoforge.fluids.capability.wrappers.FluidBucketWrapper;
@@ -14,7 +15,7 @@ public class SkyrootBucketWrapper extends FluidBucketWrapper {
 
     @Override
     public boolean canFillFluidType(FluidStack fluid) {
-        return fluid.is(AetherTags.Fluids.ALLOWED_BUCKET_PICKUP);
+        return fluid.is(AetherTags.Fluids.ALLOWED_BUCKET_PICKUP) || (NeoForgeMod.MILK_TYPE.isBound() && fluid.getFluidType() == NeoForgeMod.MILK_TYPE.get());
     }
 
     @Override


### PR DESCRIPTION
Milk wasn't allowed as fluid for filling SkyrootBucketWrapper, and then afterwards was not actually in the REPLACEMENTS map to actually be swapped.

Fixes #2752

Relates to #2569 so would be nice for this to be included in #2748 as well.

---

I agree to the Contributor License Agreement (CLA).
