### PR TITLE
Possible fix for issue #2770.

### DIFF
--- a/src/main/java/com/aetherteam/aether/api/registers/MoaType.java
+++ b/src/main/java/com/aetherteam/aether/api/registers/MoaType.java
@@ -4,18 +4,20 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 
 import java.util.Optional;
 
 public record MoaType(ItemStack egg, int maxJumps, float speed, int spawnChance, ResourceLocation moaTexture, ResourceLocation saddleTexture, Optional<ResourceLocation> jumpsTexture) {
+
     public static final Codec<MoaType> CODEC =
-        RecordCodecBuilder.create(in -> in.group(
-            ItemStack.SINGLE_ITEM_CODEC.fieldOf("egg").forGetter(MoaType::egg),
+        Codec.lazyInitialized(() -> RecordCodecBuilder.create(in -> in.group(
+            ItemStack.SINGLE_ITEM_CODEC.fieldOf("egg").orElseGet(Items.EGG::getDefaultInstance).forGetter(MoaType::egg),
             Codec.INT.fieldOf("max_jumps").forGetter(MoaType::maxJumps),
             Codec.FLOAT.fieldOf("speed").forGetter(MoaType::speed),
             Codec.INT.fieldOf("spawn_chance").forGetter(MoaType::spawnChance),
             ResourceLocation.CODEC.fieldOf("moa_texture").forGetter(MoaType::moaTexture),
             ResourceLocation.CODEC.fieldOf("saddle_texture").forGetter(MoaType::saddleTexture),
             ResourceLocation.CODEC.optionalFieldOf("jumps_texture").forGetter(MoaType::jumpsTexture)
-        ).apply(in, MoaType::new));
+        ).apply(in, MoaType::new)));
 }


### PR DESCRIPTION
Based on errors of various users, and a brief code analysis, the cause of issue #2770 could be related to the MoaType CODEC retrieval somehow failing to read the egg item, as if the item didn't exist.

I changed the codec definition to be lazy initialized, with a fallback Vanilla egg, so that players should supposedly still be able to join servers that find themselves in such a situation.

I couldn't test the fix as I cannot recreate the conditions of the issue. This means it might not be enough to resolve it.

---

I agree to the Contributor License Agreement (CLA).
