### PR TITLE
Fix dedicated-server crash by avoiding mixin-injected holder lookup in death callback

### DIFF
--- a/src/main/java/com/aetherteam/aether/event/listeners/EntityListener.java
+++ b/src/main/java/com/aetherteam/aether/event/listeners/EntityListener.java
@@ -52,7 +52,10 @@ public class EntityListener {
         OnDeathCallback.EVENT.register((currentState, entity, capability, damageSource, droppedStacks) -> {
             List<ItemStack> droppedStacksCopy = new ArrayList<>(droppedStacks);
             boolean recentlyHit = entity.hurtMarked;
-            int looting = EnchantmentHelper.getEnchantmentLevel(entity.level().registryAccess().aetherFabric$holderOrThrow(Enchantments.LOOTING), entity);
+            int looting = EnchantmentHelper.getEnchantmentLevel(
+                    entity.level().registryAccess().lookupOrThrow(Enchantments.LOOTING.registryKey()).getOrThrow(Enchantments.LOOTING),
+                    entity
+            );
             droppedStacks.clear();
             droppedStacks.addAll(EntityHooks.handleEntityAccessoryDrops(entity, droppedStacksCopy, recentlyHit, looting));
             return TriState.DEFAULT;


### PR DESCRIPTION
Summary
This PR fixes a dedicated-server crash path in `EntityListener` by removing the call to `registryAccess().aetherFabric$holderOrThrow(...)` and using vanilla holder lookup directly.

Problem
On dedicated servers, the death callback can hit:
- `java.lang.NoSuchMethodError: DynamicRegistryManager.aetherFabric$holderOrThrow(...)`

This happens in the loot calculation path for Accessories `OnDeathCallback` when getting the Looting enchantment holder.

Change
File:
- `src/main/java/com/aetherteam/aether/event/listeners/EntityListener.java`

Replacement:
- before: `registryAccess().aetherFabric$holderOrThrow(Enchantments.LOOTING)`
- after: `registryAccess().lookupOrThrow(Enchantments.LOOTING.registryKey()).getOrThrow(Enchantments.LOOTING)`

Why this is safer
- Uses vanilla registry access APIs only.
- Removes dependency on a mixin-injected extension method in a critical server death path.
- Keeps behavior identical for Looting level computation.

Validation performed
- Change is isolated to one file and one call path.
- Local Gradle compile could not be completed in this environment due Java/Gradle compatibility (`Unsupported class file major version 69`), so CI validation is requested.

Issues
- Intended to address dedicated-server crash reports equivalent to #2815 / #2816.

Disclosure
- This fix was vibe coded with assistance from LLM tooling, then manually reviewed and minimized to a single targeted change.