### PR TITLE
fix(docs): fix incorrect resources path in agreement

### DIFF
--- a/docs/AGREEMENT.md
+++ b/docs/AGREEMENT.md
@@ -2,7 +2,7 @@
 By making contributions to this repository you are hereby agreeing that:
 
 - You grant The Aether Team and other users the right to use your contributions under one of the following respective licenses:
-    - [All Rights Reserved](https://en.wikipedia.org/wiki/All_rights_reserved) for contributed or updated assets in `/src/main/java/resources`.
+    - [All Rights Reserved](https://en.wikipedia.org/wiki/All_rights_reserved) for contributed or updated assets in `/src/main/resources`.
     - [LGPL v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html) for code or other changes.
 - Your contributions are of your own work and are free of legal restrictions (such as patents or copyrights).
 


### PR DESCRIPTION
Update the CLA asset path reference from `/src/main/java/resources` to `/src/main/resources` to match the actual project structure.

---

I agree to the Contributor License Agreement (CLA).
